### PR TITLE
Rename department.role_department to slug

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -21,6 +21,6 @@ class Permission
   private
 
   def department_matches?(department)
-    department.role_department == department_slug
+    department.slug == department_slug
   end
 end

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -5,7 +5,7 @@ class DepartmentPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(role_department: permissions.department_slugs).order(:name)
+      scope.where(slug: permissions.department_slugs).order(:name)
     end
   end
 end

--- a/db/migrate/20150603154604_rename_role_department.rb
+++ b/db/migrate/20150603154604_rename_role_department.rb
@@ -1,0 +1,6 @@
+class RenameRoleDepartment < ActiveRecord::Migration
+  def change
+    rename_column :departments, :role_department, :slug
+    add_index :departments, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150602184917) do
+ActiveRecord::Schema.define(version: 20150603154604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,8 +25,10 @@ ActiveRecord::Schema.define(version: 20150602184917) do
 
   create_table "departments", force: :cascade do |t|
     t.string "name"
-    t.string "role_department"
+    t.string "slug"
   end
+
+  add_index "departments", ["slug"], name: "index_departments_on_slug", unique: true, using: :btree
 
   create_table "direct_assessments", force: :cascade do |t|
     t.string  "subject_number"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,13 +7,13 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 ActiveRecord::Base.transaction do
-  Department.find_or_create_by(name: "Civil and Environmental Engineering", role_department: "D_CEE")
-  Department.find_or_create_by(name: "Mechanical Engineering", role_department: "D_MECHE")
-  Department.find_or_create_by(name: "DMSE", role_department: "D_DMSE")
-  Department.find_or_create_by(name: "EECS", role_department: "D_EECS")
-  Department.find_or_create_by(name: "Chemical Engineering", role_department: "D_CHEME")
-  Department.find_or_create_by(name: "Aero Astro", role_department: "D_AEROASTRO")
-  Department.find_or_create_by(name: "Nuclear Science and Engineering", role_department: "D_NUCENG")
+  Department.find_or_create_by(name: "Civil and Environmental Engineering", slug: "D_CEE")
+  Department.find_or_create_by(name: "Mechanical Engineering", slug: "D_MECHE")
+  Department.find_or_create_by(name: "DMSE", slug: "D_DMSE")
+  Department.find_or_create_by(name: "EECS", slug: "D_EECS")
+  Department.find_or_create_by(name: "Chemical Engineering", slug: "D_CHEME")
+  Department.find_or_create_by(name: "Aero Astro", slug: "D_AEROASTRO")
+  Department.find_or_create_by(name: "Nuclear Science and Engineering", slug: "D_NUCENG")
   courses = [["1-C", "Civil Engineering", "Civil and Environmental Engineering"],
   ["1-E", "Environmental Engineering", "Civil and Environmental Engineering"],
   ["1-ENG", "CEE Flexible", "Civil and Environmental Engineering"],

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -1,7 +1,7 @@
 Given /^a Touchstone authenticated user$/ do
   ENV['eppn'] = "daries@mit.edu"
-  Department.create!(name: 'Mechanical Engineering', role_department: 'D_MECHE')
-  Department.create!(name: 'Nuclear Engineering', role_department: 'D_NUCENG')
+  Department.create!(name: 'Mechanical Engineering', slug: 'D_MECHE')
+  Department.create!(name: 'Nuclear Engineering', slug: 'D_NUCENG')
   StandardOutcome.create(name:"a", description:"an ability to apply knowledge of mathematics, science, and engineering")
   StandardOutcome.create(name:"b", description:"an ability to design and conduct experiments, as well as to analyze and interpret data")
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
       "Department #{n} Name"
     end
 
-    sequence :role_department do |n|
+    sequence :slug do |n|
       "D_#{n}XX"
     end
   end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -23,10 +23,10 @@ describe Permission do
 
   describe "#read?" do
     it "is true for the provided department if you have at least read" do
-      department = Department.new(role_department: "D_FOO")
+      department = Department.new(slug: "D_FOO")
 
       permission = Permission.new(
-        department.role_department,
+        department.slug,
         Permission::READ_ONLY
       )
 
@@ -34,7 +34,7 @@ describe Permission do
     end
 
     it "is false if the permission is not for the department" do
-      department = Department.new(role_department: "D_FOO")
+      department = Department.new(slug: "D_FOO")
 
       permission = Permission.new("D_BAR", Permission::READ_ONLY)
 

--- a/spec/support/permissions_helpers.rb
+++ b/spec/support/permissions_helpers.rb
@@ -1,7 +1,7 @@
 module PermissionsHelpers
   def grant_access(user, departments, access_level)
     permissions = Array(departments).map do |department|
-      Permission.new(department.role_department, access_level)
+      Permission.new(department.slug, access_level)
     end
 
     allow(PermissionSet).to receive(:for).


### PR DESCRIPTION
This field maps to the department name from the roles database. It is a
unique, string representation of the department. We typically refer to
these as slugs. `slug` is less redundant, shorter, and I believe less
confusing than `role_department`.

I have also added a unique index to ensure that we don't duplicate these
values and make them slightly quicker to search for.