### PR TITLE
Change course schema

### DIFF
--- a/app/views/departments/show.html.erb
+++ b/app/views/departments/show.html.erb
@@ -1,15 +1,15 @@
 <div class="row">&nbsp;</div>
 <div class="row">
-	<table id="courses">
-	<tr>
-		<th class="small-6 columns">Course Number</th>
-		<th class="small-6 columns	">Course Name</th>
-	</tr>
-	<% @courses.each do |course| %>
-	<tr>
-		<td class="small-6 columns"><%=course.course_number %></td>
-		<td class="small-6 columns"><%=link_to course.course_name, course%></td>
-	</tr>
-	<% end %>
+  <table id="courses">
+  <tr>
+    <th class="small-6 columns">Course Number</th>
+    <th class="small-6 columns  ">Course Name</th>
+  </tr>
+  <% @courses.each do |course| %>
+  <tr>
+    <td class="small-6 columns"><%=course.number %></td>
+    <td class="small-6 columns"><%=link_to course.name, course%></td>
+  </tr>
+  <% end %>
 </table>
 </div>

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -7,14 +7,14 @@
 <li><%=link_to @course.department.name, department_path(@course.department) %></li>
 <li class="divider"></li>
 <li><%=link_to course_path(@course) do %>
-Course <%=@course.course_number%>
+Course <%=@course.number%>
 <% end %>
 </li>
 <% elsif not @outcome.nil? %>
 <li><%= link_to @outcome.course.department.name, department_path(@outcome.course.department)%></li>
 <li class="divider"></li>
 <li><%= link_to course_path(@outcome.course) do%>
- Course <%=@outcome.course.course_number %>
+ Course <%=@outcome.course.number %>
 <% end %>
 </li>
 <li class="divider"></li>

--- a/db/migrate/20150603155604_rename_course_fields.rb
+++ b/db/migrate/20150603155604_rename_course_fields.rb
@@ -1,0 +1,6 @@
+class RenameCourseFields < ActiveRecord::Migration
+  def change
+    rename_column :courses, :course_name, :name
+    rename_column :courses, :course_number, :number
+  end
+end

--- a/db/migrate/20150603155840_add_course_constraints.rb
+++ b/db/migrate/20150603155840_add_course_constraints.rb
@@ -1,0 +1,9 @@
+class AddCourseConstraints < ActiveRecord::Migration
+  def change
+    change_column_null :courses, :name, false
+    change_column_null :courses, :number, false
+    change_column_null :courses, :department_id, false
+    add_index :courses, :number, unique: true
+    add_foreign_key :courses, :departments, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150603154604) do
+ActiveRecord::Schema.define(version: 20150603155840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "courses", force: :cascade do |t|
-    t.string  "course_number"
-    t.string  "course_name"
-    t.integer "department_id"
+    t.string  "number",              null: false
+    t.string  "name",                null: false
+    t.integer "department_id",       null: false
     t.boolean "has_custom_outcomes"
   end
+
+  add_index "courses", ["number"], name: "index_courses_on_number", unique: true, using: :btree
 
   create_table "departments", force: :cascade do |t|
     t.string "name"
@@ -80,4 +82,5 @@ ActiveRecord::Schema.define(version: 20150603154604) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
+  add_foreign_key "courses", "departments", on_delete: :restrict
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,8 +32,8 @@ ActiveRecord::Base.transaction do
   ["22", "Nuclear Engineering", "Nuclear Science and Engineering"]]
   courses.each do |course|
     dept = Department.find_by_name(course.last)
-    Course.find_or_create_by(course_number: course[0],
-      course_name: course[1],
+    Course.find_or_create_by(number: course[0],
+      name: course[1],
       department: dept)
   end
   standard_outcomes = [

--- a/features/step_definitions/course_steps.rb
+++ b/features/step_definitions/course_steps.rb
@@ -3,8 +3,8 @@ Given(/^a department has the following courses:$/) do |table|
   @rows = table.hashes
   table.hashes.each do |row|
     Course.create(department: meche,
-      course_number: row["Course Number"],
-      course_name: row["Course Name"])
+      number: row["Course Number"],
+      name: row["Course Name"])
   end
 end
 

--- a/features/step_definitions/show_assessments_steps.rb
+++ b/features/step_definitions/show_assessments_steps.rb
@@ -1,5 +1,5 @@
 Given(/^An outcome has the following direct assessment associated with it:$/) do |table|
-  meche2 = Course.find_by_course_number("2")
+  meche2 = Course.find_by_number("2")
   outcome_a = meche2.outcomes.first
   @rows = table.hashes
     table.hashes.each do |row|

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe CoursesController do
 
   let!(:dept) { Department.find_or_create_by(name: 'Mechanical Engineering') }
-  let(:course) { Course.find_or_create_by(course_number: '2A', course_name: 'MechE', department: dept) }
+  let(:course) { Course.find_or_create_by(number: '2A', name: 'MechE', department: dept) }
 
   context "setting up default outcomes" do
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :course do
-    sequence(:course_number) { |i| i.to_s }
-    course_name { "Course #{course_number} Name" }
+    sequence(:number) { |i| i.to_s }
+    name { "Course #{number} Name" }
     department
   end
 

--- a/spec/features/user_views_department_spec.rb
+++ b/spec/features/user_views_department_spec.rb
@@ -9,7 +9,7 @@ feature "User views department" do
 
     visit department_path(course.department, as: user)
 
-    expect(page).to have_content(course.course_name)
-    expect(page).not_to have_content(other_course.course_name)
+    expect(page).to have_content(course.name)
+    expect(page).not_to have_content(other_course.name)
   end
 end


### PR DESCRIPTION
* Rename `course_name` to `name` to avoid the common
  `course.course_name` redundancy
* Rename `course_number` to `number` for similar reasons.
* Add `null: false` constraints to appropriate fields
* Make `course.number` unique
* Add a foreign key from courses to departments. The foreign key is set
  to prevent deleting departments that have courses. We can revisit this
  if need be.