### PR TITLE
Add timestamps to previously existing tables

### DIFF
--- a/db/migrate/20150603170344_add_timestamps_to_tables.rb
+++ b/db/migrate/20150603170344_add_timestamps_to_tables.rb
@@ -1,0 +1,30 @@
+class AddTimestampsToTables < ActiveRecord::Migration
+  def change
+    tables = %i(
+      courses
+      departments
+      direct_assessments
+      indirect_assessments
+      outcome_alignments
+      outcomes
+      standard_outcomes
+    )
+
+    tables.each do |table|
+      add_column table, :created_at, :datetime
+      add_column table, :updated_at, :datetime
+
+      reversible do |dir|
+        dir.up do
+          execute <<-SQL
+            UPDATE #{table}
+            SET created_at = now(), updated_at = now()
+          SQL
+        end
+      end
+
+      change_column_null table, :created_at, false
+      change_column_null table, :updated_at, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,67 +11,81 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150603155840) do
+ActiveRecord::Schema.define(version: 20150603170344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "courses", force: :cascade do |t|
-    t.string  "number",              null: false
-    t.string  "name",                null: false
-    t.integer "department_id",       null: false
-    t.boolean "has_custom_outcomes"
+    t.string   "number",              null: false
+    t.string   "name",                null: false
+    t.integer  "department_id",       null: false
+    t.boolean  "has_custom_outcomes"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
   end
 
   add_index "courses", ["number"], name: "index_courses_on_number", unique: true, using: :btree
 
   create_table "departments", force: :cascade do |t|
-    t.string "name"
-    t.string "slug"
+    t.string   "name"
+    t.string   "slug"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "departments", ["slug"], name: "index_departments_on_slug", unique: true, using: :btree
 
   create_table "direct_assessments", force: :cascade do |t|
-    t.string  "subject_number"
-    t.string  "subject_description"
-    t.string  "semester"
-    t.string  "assignment_name"
-    t.string  "assignment_description"
-    t.string  "problem_description"
-    t.string  "minimum_grade"
-    t.integer "target_percentage"
-    t.integer "actual_percentage"
-    t.integer "outcome_id"
+    t.string   "subject_number"
+    t.string   "subject_description"
+    t.string   "semester"
+    t.string   "assignment_name"
+    t.string   "assignment_description"
+    t.string   "problem_description"
+    t.string   "minimum_grade"
+    t.integer  "target_percentage"
+    t.integer  "actual_percentage"
+    t.integer  "outcome_id"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   create_table "indirect_assessments", force: :cascade do |t|
-    t.string  "assessment_name"
-    t.string  "assessment_description"
-    t.string  "survey_question"
-    t.integer "year"
-    t.string  "minimum_category"
-    t.integer "target_percentage"
-    t.integer "actual_percentage"
-    t.integer "outcome_id"
+    t.string   "assessment_name"
+    t.string   "assessment_description"
+    t.string   "survey_question"
+    t.integer  "year"
+    t.string   "minimum_category"
+    t.integer  "target_percentage"
+    t.integer  "actual_percentage"
+    t.integer  "outcome_id"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   create_table "outcome_alignments", force: :cascade do |t|
-    t.integer "outcome_id"
-    t.integer "standard_outcome_id"
-    t.string  "alignment_level"
+    t.integer  "outcome_id"
+    t.integer  "standard_outcome_id"
+    t.string   "alignment_level"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
   end
 
   create_table "outcomes", force: :cascade do |t|
-    t.string  "name"
-    t.string  "description"
-    t.integer "course_id"
-    t.integer "standard_outcome_id"
+    t.string   "name"
+    t.string   "description"
+    t.integer  "course_id"
+    t.integer  "standard_outcome_id"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
   end
 
   create_table "standard_outcomes", force: :cascade do |t|
-    t.string "name"
-    t.string "description"
+    t.string   "name"
+    t.string   "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
It's a general best practice to have timestamps be present on all
tables. This tends to be helpful somewhere along the way in auditing or
debugging.