### PR TITLE
Add authorization on course show

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,8 +1,11 @@
 class CoursesController < ApplicationController
+  after_filter :verify_authorized, only: [:show]
+
   def show
     @course = Course.find(params[:id])
     @outcomes = @course.outcomes
     @unassociated_outcomes = retrieve_unassociated_outcomes
+    authorize(@course)
   end
 
   def adopt_default

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,0 +1,5 @@
+class CoursePolicy < ApplicationPolicy
+  def show?
+    user.permissions.read?(record.department)
+  end
+end

--- a/lib/touchstone_back_door.rb
+++ b/lib/touchstone_back_door.rb
@@ -18,11 +18,13 @@ class TouchstoneBackDoor
   private
 
   def sign_in_through_the_back_door(env)
+    request = Rack::Request.new(env)
     params = Rack::Utils.parse_query(env["QUERY_STRING"])
-    user_id = params["as"]
+    user_id = params["as"] || request.session["as"]
 
     if user_id.present?
       user = User.find(user_id)
+      request.session["as"] = user.id
       env["eppn"] = user.email
     end
   end

--- a/spec/features/user_adopts_standard_outcomes_for_course_spec.rb
+++ b/spec/features/user_adopts_standard_outcomes_for_course_spec.rb
@@ -5,6 +5,7 @@ feature "User adopts standard outcomes for a course" do
     user = create(:user)
     course = create(:course)
     standard_outcome = create(:standard_outcome)
+    grant_access(user, course.department, Permission::ADMIN)
 
     visit course_path(course, as: user)
     click_on "Adopt Default Outcomes"

--- a/spec/features/user_creates_an_assessment_spec.rb
+++ b/spec/features/user_creates_an_assessment_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 feature "User creates an assessment" do
   scenario "the outcome description is displayed on the new assessment page" do
     outcome = create(:outcome)
+    user = create(:user)
+    grant_access(user, outcome.course.department, Permission::ADMIN)
 
-    visit course_path(outcome.course)
+    visit course_path(outcome.course, as: user)
     within("#outcome-#{outcome.id}") do
       click_on "Add new assessment"
     end
@@ -15,8 +17,10 @@ feature "User creates an assessment" do
 
   scenario "a new assessment is created" do
     outcome = create(:outcome)
+    user = create(:user)
+    grant_access(user, outcome.course.department, Permission::ADMIN)
 
-    visit course_path(outcome.course)
+    visit course_path(outcome.course, as: user)
     within("#outcome-#{outcome.id}") do
       click_on "Add new assessment"
     end

--- a/spec/features/user_creates_custom_outcomes_spec.rb
+++ b/spec/features/user_creates_custom_outcomes_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 feature "User creates custom outcomes" do
-  scenario "user adds a custom outcome" do
+  scenario "adds first custom outcome" do
     course = create(:course)
     associated_outcome, unassociated_outcome = create_pair(:standard_outcome)
+    user = create(:user)
+    grant_access(user, course.department, Permission::ADMIN)
 
-    visit course_path(course)
+    visit course_path(course, as: user)
     click_on "Create Custom Outcomes"
 
     fill_in "outcome_name", with: "A.1.a"
@@ -30,12 +32,14 @@ feature "User creates custom outcomes" do
     end
   end
 
-  scenario "user adds additional custom outcome" do
+  scenario "adds additional custom outcome" do
     standard_outcome = create(:standard_outcome)
     course = create(:course, has_custom_outcomes: true)
     custom_outcome = create(:outcome, course: course)
+    user = create(:user)
+    grant_access(user, course.department, Permission::ADMIN)
 
-    visit course_path(course)
+    visit course_path(course, as: user)
 
     expect(page).to have_content(custom_outcome.name)
     expect(page).to have_content(custom_outcome.description)

--- a/spec/features/user_visits_outcome_spec.rb
+++ b/spec/features/user_visits_outcome_spec.rb
@@ -5,8 +5,10 @@ feature "User visits outcome" do
     outcome = create(:outcome)
     direct_assessment = create(:direct_assessment, outcome: outcome)
     indirect_assessment = create(:indirect_assessment, outcome: outcome)
+    user = create(:user)
+    grant_access(user, outcome.course.department, Permission::ADMIN)
 
-    visit course_path(outcome.course)
+    visit course_path(outcome.course, as: user)
 
     within("#outcome-#{outcome.id}") do
       click_on "Details"


### PR DESCRIPTION
Authorization is driven by the department level access. If you have read
only access to the department for the course, then you can view the
course.

I had to update the back door code for tests so that the supplied user
carries over to additional requests after the initial visit call. This
is done by storing the user id in the session.