### PR TITLE
Add authorization to assessments

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -1,5 +1,8 @@
 class AssessmentsController < ApplicationController
+  after_filter :verify_authorized
+
   def new
     @outcome = Outcome.find_by_id(params[:outcome_id])
+    authorize(@outcome, :create_assessments?)
   end
 end

--- a/app/controllers/concerns/assessment_authorization.rb
+++ b/app/controllers/concerns/assessment_authorization.rb
@@ -1,0 +1,13 @@
+module AssessmentAuthorization
+  extend ActiveSupport::Concern
+
+  included do
+    after_filter :verify_authorized
+  end
+
+  def authorize(assessment)
+    query = action_name + "?"
+    @_pundit_policy_authorized = true
+    AssessmentPolicy.new(current_user, assessment).public_send(query)
+  end
+end

--- a/app/controllers/direct_assessments_controller.rb
+++ b/app/controllers/direct_assessments_controller.rb
@@ -1,13 +1,18 @@
 class DirectAssessmentsController < ApplicationController
+  include AssessmentAuthorization
+
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @assessment = DirectAssessment.new
+    @assessment = @outcome.direct_assessments.build
     @available_semesters = ['2015FA', '2015JA', '2015SP']
+    authorize(@assessment)
   end
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
-      @direct_assessment = @outcome.direct_assessments.build(direct_assessment_params)
+    @direct_assessment = @outcome.direct_assessments.build(direct_assessment_params)
+    authorize(@direct_assessment)
+
     if @direct_assessment.save
       redirect_to outcome_path(@outcome)
     else
@@ -19,11 +24,14 @@ class DirectAssessmentsController < ApplicationController
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = DirectAssessment.find(params[:id])
     @available_semesters = ['2015FA', '2015JA', '2015SP']
+    authorize(@assessment)
   end
 
   def update
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = DirectAssessment.find(params[:id])
+    authorize(@assessment)
+
     @assessment.assign_attributes(direct_assessment_params)
     if @assessment.save
       redirect_to outcome_path(@outcome)
@@ -41,4 +49,3 @@ class DirectAssessmentsController < ApplicationController
       :minimum_grade, :target_percentage, :actual_percentage)
   end
 end
-

--- a/app/controllers/other_assessments_controller.rb
+++ b/app/controllers/other_assessments_controller.rb
@@ -1,13 +1,17 @@
 class OtherAssessmentsController < ApplicationController
+  include AssessmentAuthorization
+
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @other_assessment = OtherAssessment.new
+    @other_assessment = @outcome.other_assessments.build
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
+    authorize(@other_assessment)
   end
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
     @other_assessment = @outcome.other_assessments.build(other_assessment_params)
+    authorize(@other_assessment)
 
     if @other_assessment.save
       redirect_to outcome_path(@outcome)
@@ -20,12 +24,14 @@ class OtherAssessmentsController < ApplicationController
     @outcome = Outcome.find(params[:outcome_id])
     @other_assessment = OtherAssessment.find(params[:id])
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
+    authorize(@other_assessment)
   end
 
   def update
     @outcome = Outcome.find(params[:outcome_id])
     @other_assessment = OtherAssessment.find(params[:id])
     @other_assessment.assign_attributes(other_assessment_params)
+    authorize(@other_assessment)
 
     if @other_assessment.save
       redirect_to outcome_path(@outcome)

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,13 +1,17 @@
 class ParticipationsController < ApplicationController
+  include AssessmentAuthorization
+
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @participation = Participation.new
+    @participation = @outcome.participations.build
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
+    authorize(@participation)
   end
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
     @participation = @outcome.participations.build(participation_params)
+    authorize(@participation)
 
     if @participation.save
       redirect_to outcome_path(@outcome)
@@ -20,12 +24,14 @@ class ParticipationsController < ApplicationController
     @outcome = Outcome.find(params[:outcome_id])
     @participation = Participation.find(params[:id])
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
+    authorize(@participation)
   end
 
   def update
     @outcome = Outcome.find(params[:outcome_id])
     @participation = Participation.find(params[:id])
     @participation.assign_attributes(participation_params)
+    authorize(@participation)
 
     if @participation.save
       redirect_to outcome_path(@outcome)

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,13 +1,17 @@
 class SurveysController < ApplicationController
+  include AssessmentAuthorization
+
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @survey = Survey.new
+    @survey = @outcome.surveys.build
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
+    authorize(@survey)
   end
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
     @survey = @outcome.surveys.build(survey_params)
+    authorize(@survey)
 
     if @survey.save
       redirect_to outcome_path(@outcome)
@@ -20,12 +24,14 @@ class SurveysController < ApplicationController
     @outcome = Outcome.find(params[:outcome_id])
     @survey = Survey.find(params[:id])
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
+    authorize(@survey)
   end
 
   def update
     @outcome = Outcome.find(params[:outcome_id])
     @survey = Survey.find(params[:id])
     @survey.assign_attributes(survey_params)
+    authorize(@survey)
 
     if @survey.save
       redirect_to outcome_path(@outcome)

--- a/app/policies/assessment_policy.rb
+++ b/app/policies/assessment_policy.rb
@@ -1,0 +1,9 @@
+class AssessmentPolicy < ApplicationPolicy
+  def create?
+    user.permissions.admin?(record.outcome.course.department)
+  end
+
+  def update?
+    create?
+  end
+end

--- a/app/policies/outcome_policy.rb
+++ b/app/policies/outcome_policy.rb
@@ -6,4 +6,8 @@ class OutcomePolicy < ApplicationPolicy
   def create?
     user.permissions.admin?(record.course.department)
   end
+
+  def create_assessments?
+    create?
+  end
 end


### PR DESCRIPTION
I used a concern here to map all assessment types to the same assessment
policy. Having completed all of the policies now, I'm concerned that
there's a lot of demeter violations to get back to the department which
is what we are always authorizing on. I may investigate ways to ease
these demeter violations, but I think it would require more
associations. Not sure that's a good trade off.