### PR TITLE
Centralize authorization verification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::Base
   include Pundit
+
   protect_from_forgery with: :exception
+  after_action :verify_authorized, except: [:index]
+  after_action :verify_policy_scoped, only: [:index]
 
   private
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -1,6 +1,4 @@
 class AssessmentsController < ApplicationController
-  after_filter :verify_authorized
-
   def new
     @outcome = Outcome.find_by_id(params[:outcome_id])
     authorize(@outcome, :create_assessments?)

--- a/app/controllers/concerns/assessment_authorization.rb
+++ b/app/controllers/concerns/assessment_authorization.rb
@@ -1,10 +1,6 @@
 module AssessmentAuthorization
   extend ActiveSupport::Concern
 
-  included do
-    after_filter :verify_authorized
-  end
-
   def authorize(assessment)
     query = action_name + "?"
     @_pundit_policy_authorized = true

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,4 @@
 class CoursesController < ApplicationController
-  after_filter :verify_authorized, only: [:show]
-
   def show
     @course = Course.find(params[:id])
     @outcomes = @course.outcomes

--- a/app/controllers/default_outcomes_controller.rb
+++ b/app/controllers/default_outcomes_controller.rb
@@ -1,6 +1,4 @@
 class DefaultOutcomesController < ApplicationController
-  after_filter :verify_authorized
-
   def create
     course = Course.find(params[:course_id])
     authorize(course, :create_outcomes?)

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -1,6 +1,4 @@
 class DepartmentsController < ApplicationController
-  after_action :verify_authorized
-
   def show
     @department = Department.find(params[:id])
     @courses = @department.courses

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,6 @@
 class HomeController < ApplicationController
   before_action :ensure_user_can_access
   before_action :redirect_to_sole_department
-  after_action :verify_policy_scoped
 
   def index
     @departments = authorized_departments

--- a/app/controllers/outcomes_controller.rb
+++ b/app/controllers/outcomes_controller.rb
@@ -1,6 +1,4 @@
 class OutcomesController < ApplicationController
-  after_filter :verify_authorized
-
   def show
     @outcome = Outcome.find(params[:id])
     @direct_assessments = @outcome.direct_assessments

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe ApplicationController do
   controller do
+    skip_after_action :verify_policy_scoped
+
     def index
       render text: current_user.email
     end


### PR DESCRIPTION
Now that all of the controllers have appropriate authorization calls, we
can move the filters into the application controller. This will ensure
that any new controllers require authorization to be set up properly or
intentionally skipped with `skip_after_filter`.