### PR TITLE
Add ability to clone assessments

### DIFF
--- a/app/controllers/direct_assessments_controller.rb
+++ b/app/controllers/direct_assessments_controller.rb
@@ -3,7 +3,7 @@ class DirectAssessmentsController < ApplicationController
 
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @assessment = @outcome.direct_assessments.build
+    @assessment = @outcome.direct_assessments.build(new_assessment_attributes)
     @available_semesters = ['2015FA', '2015JA', '2015SP']
     authorize(@assessment)
   end
@@ -41,6 +41,19 @@ class DirectAssessmentsController < ApplicationController
   end
 
   private
+
+  def new_assessment_attributes
+    if params[:assessment_id]
+      cloned_assessment = DirectAssessment.find(params[:assessment_id])
+      cloned_assessment.attributes.except!(*non_cloned_attributes)
+    else
+      {}
+    end
+  end
+
+  def non_cloned_attributes
+    ["id", "created_at", "updated_at", "actual_percentage"]
+  end
 
   def direct_assessment_params
     params.require(:direct_assessment).permit(:subject_number,

--- a/app/views/outcomes/show.html.erb
+++ b/app/views/outcomes/show.html.erb
@@ -29,6 +29,7 @@
       <th>Target Percentage</th>
       <th>Actual Percentage</th>
       <th></th>
+      <th></th>
     </tr>
     <% @direct_assessments.each do |assessment| %>
       <tr id="direct_assessment-<%=assessment.id %>">
@@ -41,6 +42,7 @@
         <td><%= assessment.target_percentage%></td>
         <td><%= assessment.actual_percentage%></td>
         <td><%= link_to "Edit", edit_outcome_direct_assessment_path(@outcome, assessment) %>
+        <td><%= link_to "Clone", new_outcome_direct_assessment_path(@outcome, assessment_id: assessment.id) %>
       </tr>
     <% end %>
   </table>

--- a/spec/features/user_clones_a_direct_assessment_spec.rb
+++ b/spec/features/user_clones_a_direct_assessment_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+feature "User clones a direct assessment" do
+  scenario "it creates a new assessment defaulting to the same attributes" do
+    assessment = create(
+      :direct_assessment,
+      subject_description: "Theoretical Physics",
+      semester: "2015FA"
+    )
+    outcome = assessment.outcome
+    user = user_with_admin_access_to(outcome.course.department)
+
+    visit outcome_path(outcome, as: user)
+
+    within("#direct_assessment-#{assessment.id}") do
+      click_on "Clone"
+    end
+
+    select "2015JA", from: "direct_assessment_semester"
+    click_on "Submit"
+
+    rows = all(:xpath, "//table/tr[contains(@id,'direct_assessment')]")
+
+    expect(rows.first).to have_content("2015FA")
+    expect(rows.first).to have_content("Theoretical Physics")
+
+    expect(rows.last).to have_content("2015JA")
+    expect(rows.last).to have_content("Theoretical Physics")
+  end
+end


### PR DESCRIPTION
When a user clicks "Clone" next to a direct assessment, they are brought to a form that is prefilled with the attributes of that assessment (except for the actual percentage) so that they can easily create a new assessment that defaults to the attributes of the cloned one.