### PR TITLE
Allow cloning of indirect assessments

### DIFF
--- a/app/controllers/concerns/assessment_cloning.rb
+++ b/app/controllers/concerns/assessment_cloning.rb
@@ -1,0 +1,16 @@
+module AssessmentCloning
+  extend ActiveSupport::Concern
+
+  def new_assessment_attributes
+    if params[:assessment_id]
+      cloned_assessment = IndirectAssessment.find(params[:assessment_id])
+      cloned_assessment.attributes.except!(*non_cloned_attributes)
+    else
+      {}
+    end
+  end
+
+  def non_cloned_attributes
+    ["id", "created_at", "updated_at", "actual_percentage"]
+  end
+end

--- a/app/controllers/other_assessments_controller.rb
+++ b/app/controllers/other_assessments_controller.rb
@@ -1,9 +1,10 @@
 class OtherAssessmentsController < ApplicationController
   include AssessmentAuthorization
+  include AssessmentCloning
 
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @other_assessment = @outcome.other_assessments.build
+    @other_assessment = @outcome.other_assessments.build(new_assessment_attributes)
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
     authorize(@other_assessment)
   end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,9 +1,10 @@
 class ParticipationsController < ApplicationController
   include AssessmentAuthorization
+  include AssessmentCloning
 
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @participation = @outcome.participations.build
+    @participation = @outcome.participations.build(new_assessment_attributes)
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
     authorize(@participation)
   end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,9 +1,10 @@
 class SurveysController < ApplicationController
   include AssessmentAuthorization
+  include AssessmentCloning
 
   def new
     @outcome = Outcome.find(params[:outcome_id])
-    @survey = @outcome.surveys.build
+    @survey = @outcome.surveys.build(new_assessment_attributes)
     @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
     authorize(@survey)
   end

--- a/app/views/outcomes/show.html.erb
+++ b/app/views/outcomes/show.html.erb
@@ -72,7 +72,8 @@
         <td><%= assessment.target_percentage%></td>
         <td><%= assessment.actual_percentage%></td>
         <td><%= assessment_type(assessment) %></td>
-        <td><%= link_to "Edit", url_for([:edit, @outcome, assessment]) %></td>
+        <td><%= link_to "Edit", edit_polymorphic_path([@outcome, assessment]) %></td>
+        <td><%= link_to "Clone", new_polymorphic_path([@outcome, assessment], assessment_id: assessment.id) %>
       </tr>
     <% end %>
   </table>

--- a/spec/features/user_clones_a_participation_assessment_spec.rb
+++ b/spec/features/user_clones_a_participation_assessment_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+feature "User clones a participation assessment" do
+  scenario "it creates a new assessment defaulting to the same attributes" do
+    assessment = create(
+      :participation,
+      assessment_name: "UROP",
+      year: 2014
+    )
+    outcome = assessment.outcome
+    user = user_with_admin_access_to(outcome.course.department)
+
+    visit outcome_path(outcome, as: user)
+
+    within("#indirect_assessment-#{assessment.id}") do
+      click_on "Clone"
+    end
+
+    select "2015", from: "participation_year"
+    click_on "Submit"
+
+    rows = all(:xpath, "//table/tr[contains(@id,'indirect_assessment')]")
+
+    expect(rows.first).to have_content("2014")
+    expect(rows.first).to have_content("UROP")
+
+    expect(rows.last).to have_content("2015")
+    expect(rows.last).to have_content("UROP")
+  end
+end

--- a/spec/features/user_clones_a_survey_assessment_spec.rb
+++ b/spec/features/user_clones_a_survey_assessment_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+feature "User clones a survey assessment" do
+  scenario "it creates a new assessment defaulting to the same attributes" do
+    assessment = create(
+      :survey,
+      assessment_name: "Senior Survey",
+      year: 2014
+    )
+    outcome = assessment.outcome
+    user = user_with_admin_access_to(outcome.course.department)
+
+    visit outcome_path(outcome, as: user)
+
+    within("#indirect_assessment-#{assessment.id}") do
+      click_on "Clone"
+    end
+
+    select "2015", from: "survey_year"
+    click_on "Submit"
+
+    rows = all(:xpath, "//table/tr[contains(@id,'indirect_assessment')]")
+
+    expect(rows.first).to have_content("2014")
+    expect(rows.first).to have_content("Senior Survey")
+
+    expect(rows.last).to have_content("2015")
+    expect(rows.last).to have_content("Senior Survey")
+  end
+end

--- a/spec/features/user_clones_other_assessment_spec.rb
+++ b/spec/features/user_clones_other_assessment_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+feature "User clones other assessment" do
+  scenario "it creates a new assessment defaulting to the same attributes" do
+    assessment = create(
+      :other_assessment,
+      assessment_name: "UROP",
+      year: 2014
+    )
+    outcome = assessment.outcome
+    user = user_with_admin_access_to(outcome.course.department)
+
+    visit outcome_path(outcome, as: user)
+
+    within("#indirect_assessment-#{assessment.id}") do
+      click_on "Clone"
+    end
+
+    select "2015", from: "other_assessment_year"
+    click_on "Submit"
+
+    rows = all(:xpath, "//table/tr[contains(@id,'indirect_assessment')]")
+
+    expect(rows.first).to have_content("2014")
+    expect(rows.first).to have_content("Senior Thesis Completion")
+
+    expect(rows.last).to have_content("2015")
+    expect(rows.last).to have_content("Senior Thesis Completion")
+  end
+end


### PR DESCRIPTION
Use a concern to avoid duplication of cloning logic in controllers.

I's like to be able to use the concern for direct assessments as well, but I couldn't think of a clean way of removing the model from the concern.

It would also be nice if there were a way to reduce duplication in the feature specs, like shared examples but for features.