### PR TITLE
Render a 401 error on unauthorized requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   after_action :verify_authorized, except: [:index]
   after_action :verify_policy_scoped, only: [:index]
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
 
@@ -17,5 +18,9 @@ class ApplicationController < ActionController::Base
 
   def eppn
     request.env["eppn"] || ENV["eppn"]
+  end
+
+  def user_not_authorized
+    render file: "public/401.html", status: :unauthorized
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,7 +10,7 @@ class HomeController < ApplicationController
 
   def ensure_user_can_access
     if authorized_departments.empty?
-      render file: "public/401.html", status: :unauthorized
+      user_not_authorized
     end
   end
 

--- a/public/401.html
+++ b/public/401.html
@@ -1,1 +1,1 @@
-<p>We're sorry, but you do not have access to this application</p>
+<p>We're sorry, but your account is not authorized to complete this request.</p>

--- a/spec/controllers/departments_controller_spec.rb
+++ b/spec/controllers/departments_controller_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 describe DepartmentsController do
   describe "#show" do
-    it "raises an error if not authorized" do
+    it "renders a 401 if not authorized" do
       sign_in
       department = create(:department)
 
-      expect { get :show, id: department }.
-        to raise_error(Pundit::NotAuthorizedError)
+      get :show, id: department
+
+      expect(response.status).to eq 401
     end
   end
 end


### PR DESCRIPTION
Previously, unauthorized requests resulted in a 500 error. This change
turns those exceptions into 401 errors.