### PR TITLE
Clean up Demeter violations with delegation

### DIFF
--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,3 +1,5 @@
 class DirectAssessment < ActiveRecord::Base
   belongs_to :outcome
+
+  delegate :department, to: :outcome
 end

--- a/app/models/indirect_assessment.rb
+++ b/app/models/indirect_assessment.rb
@@ -1,3 +1,5 @@
 class IndirectAssessment < ActiveRecord::Base
   belongs_to :outcome
+
+  delegate :department, to: :outcome
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -7,4 +7,6 @@ class Outcome < ActiveRecord::Base
   has_many :other_assessments
   has_many :outcome_alignments
   accepts_nested_attributes_for :outcome_alignments
+
+  delegate :department, to: :course
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   validates :email, presence: true, email: true
 
+  delegate :admin?, :read?, :department_slugs, to: :permissions
+
   def username
     email.split("@").first
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -49,11 +49,5 @@ class ApplicationPolicy
     def resolve
       scope
     end
-
-    private
-
-    def permissions
-      user.permissions
-    end
   end
 end

--- a/app/policies/assessment_policy.rb
+++ b/app/policies/assessment_policy.rb
@@ -1,6 +1,6 @@
 class AssessmentPolicy < ApplicationPolicy
   def create?
-    user.permissions.admin?(record.outcome.course.department)
+    user.admin?(record.department)
   end
 
   def update?

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,9 +1,9 @@
 class CoursePolicy < ApplicationPolicy
   def show?
-    user.permissions.read?(record.department)
+    user.read?(record.department)
   end
 
   def create_outcomes?
-    user.permissions.admin?(record.department)
+    user.admin?(record.department)
   end
 end

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -1,11 +1,11 @@
 class DepartmentPolicy < ApplicationPolicy
   def show?
-    user.permissions.read?(record)
+    user.read?(record)
   end
 
   class Scope < Scope
     def resolve
-      scope.where(slug: permissions.department_slugs).order(:name)
+      scope.where(slug: user.department_slugs).order(:name)
     end
   end
 end

--- a/app/policies/outcome_policy.rb
+++ b/app/policies/outcome_policy.rb
@@ -1,10 +1,10 @@
 class OutcomePolicy < ApplicationPolicy
   def show?
-    user.permissions.read?(record.course.department)
+    user.read?(record.department)
   end
 
   def create?
-    user.permissions.admin?(record.course.department)
+    user.admin?(record.department)
   end
 
   def create_assessments?


### PR DESCRIPTION
By using delegation, we can avoid jumping through method chains, which
can be brittle. Delegation means that if the structure changes we can
update it in one place rather than spread out through the application.