### PR TITLE
Enable creation of results for indirect assessments

### DIFF
--- a/app/controllers/direct_assessments_controller.rb
+++ b/app/controllers/direct_assessments_controller.rb
@@ -4,7 +4,6 @@ class DirectAssessmentsController < ApplicationController
   def new
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = @outcome.direct_assessments.build
-    @available_semesters = ['2015FA', '2015JA', '2015SP']
     authorize(@assessment)
   end
 
@@ -22,7 +21,6 @@ class DirectAssessmentsController < ApplicationController
 
   def edit
     @assessment = DirectAssessment.find(params[:id])
-    @available_semesters = ['2015FA', '2015JA', '2015SP']
     authorize(@assessment)
   end
 
@@ -48,9 +46,9 @@ class DirectAssessmentsController < ApplicationController
   def direct_assessment_params
     params.require(:direct_assessment).permit(
       :actual_percentage,
-      :assignment_description,
-      :assignment_name,
+      :description,
       :minimum_grade,
+      :name,
       :problem_description,
       :semester,
       :subject_id,

--- a/app/controllers/indirect_assessments_controller.rb
+++ b/app/controllers/indirect_assessments_controller.rb
@@ -4,7 +4,6 @@ class IndirectAssessmentsController < ApplicationController
   def new
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = @outcome.indirect_assessments.build(type: params[:type])
-    @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
     authorize(@assessment)
   end
 
@@ -22,7 +21,6 @@ class IndirectAssessmentsController < ApplicationController
 
   def edit
     @assessment = IndirectAssessment.find(params[:id])
-    @available_years = ['2014', '2015', '2016', '2017', '2018', '2019']
     authorize(@assessment)
   end
 
@@ -38,13 +36,18 @@ class IndirectAssessmentsController < ApplicationController
     end
   end
 
+  def show
+    @assessment = IndirectAssessment.find(params[:id])
+    authorize(@assessment)
+  end
+
   private
 
   def assessment_params
     params.require(:indirect_assessment).permit(
       :actual_percentage,
-      :assessment_description,
-      :assessment_name,
+      :description,
+      :name,
       :target_percentage,
       :type,
       :year

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,17 +1,17 @@
 class ResultsController < ApplicationController
   def new
-    @assessment = DirectAssessment.find(params[:direct_assessment_id])
+    @assessment = find_assessment
     @result = @assessment.results.build
     authorize(@result)
   end
 
   def create
-    @assessment = DirectAssessment.find(params[:direct_assessment_id])
+    @assessment = find_assessment
     @result = @assessment.results.build(result_params)
     authorize(@result)
 
     if @result.save
-      redirect_to direct_assessment_path(@assessment)
+      redirect_to url_for(@assessment)
     else
       render :new
     end
@@ -28,5 +28,13 @@ class ResultsController < ApplicationController
       :semester,
       :year
     )
+  end
+
+  def find_assessment
+    if params[:direct_assessment_id]
+      @assessment = DirectAssessment.find(params[:direct_assessment_id])
+    else
+      @assessment = IndirectAssessment.find(params[:indirect_assessment_id])
+    end
   end
 end

--- a/app/views/direct_assessments/_form.html.erb
+++ b/app/views/direct_assessments/_form.html.erb
@@ -3,14 +3,6 @@
     <div class="small-10 large-12">
       <div class="row">
         <div class="small-2 columns">
-          <%=f.label "Semester", class: "left inline"%>
-        </div>
-        <div class="small-2 columns end">
-          <%=f.select :semester, options_for_select(@available_semesters)%>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
           <%= f.label :subject_id, class: "left inline" %>
         </div>
         <div class="small-2 columns end">
@@ -23,7 +15,7 @@
           <%= f.label "Assignment Name", class: "left inline"%>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assignment_name, :placeholder => "e.g. Problem Set 1" %>
+          <%=f.text_field :name, :placeholder => "e.g. Problem Set 1" %>
         </div>
       </div>
       <div class="row">
@@ -31,7 +23,7 @@
           <%= f.label "Assignment Description", class: "left inline"%>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assignment_description, :placeholder => "e.g. 'Integration'" %>
+          <%=f.text_field :description, :placeholder => "e.g. 'Integration'" %>
         </div>
       </div>
       <div class="row">
@@ -56,14 +48,6 @@
         </div>
         <div class="small-4 columns end">
           <%=f.text_field	:target_percentage, :placeholder => "Whole number, e.g. '80' for '80%'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label "Actual Percentage", class: "left inline"%>
-        </div>
-        <div class="small-4 columns end">
-          <%=f.text_field :actual_percentage, :placeholder => "Whole number, e.g. '80' for '80%'" %>
         </div>
       </div>
     </div>

--- a/app/views/indirect_assessments/show.html.erb
+++ b/app/views/indirect_assessments/show.html.erb
@@ -1,0 +1,21 @@
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Description</th>
+    <th>Problem Description</th>
+    <th>Year</th>
+    <th>Semester</th>
+    <th>Percentage</th>
+  </tr>
+  <% @assessment.results.each do |result| %>
+    <tr>
+      <td><%= result.assessment_name %></td>
+      <td><%= result.assessment_description %></td>
+      <td><%= result.year %></td>
+      <td><%= result.semester %></td>
+      <td><%= result.percentage %></td>
+    </tr>
+  <% end %>
+</table>
+
+<%= link_to "Add result", new_indirect_assessment_result_path(@assessment) %>

--- a/app/views/other_assessments/_other_assessment_form.html.erb
+++ b/app/views/other_assessments/_other_assessment_form.html.erb
@@ -6,7 +6,7 @@
           <%=f.label "Assessment Name", class: "left inline" %>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assessment_name, placeholder: "e.g. 'Senior Thesis Completion'" %>
+          <%=f.text_field :name, placeholder: "e.g. 'Senior Thesis Completion'" %>
         </div>
       </div>
       <div class="row">
@@ -14,15 +14,7 @@
           <%=f.label "Assessment Description", class: "left inline"%>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assessment_description, placeholder: "e.g. 'Percent of students who complete a senior thesis'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%=f.label "Year", class: "left inline" %>
-        </div>
-        <div class="small-2 columns end">
-          <%=f.select :year, @available_years  %>
+          <%=f.text_field :description, placeholder: "e.g. 'Percent of students who complete a senior thesis'" %>
         </div>
       </div>
       <div class="row">
@@ -33,15 +25,7 @@
           <%=f.text_field :target_percentage, placeholder: "Whole number, e.g. '80' for '80%'" %>
         </div>
       </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%=f.label "Actual  Percentage", class: "left inline" %>
-        </div>
-        <div class="small-4 columns end">
-          <%=f.text_field :actual_percentage, placeholder:  "Whole number, e.g. '80' for '80%'" %>
-        </div>
-        <%= f.hidden_field :type, value: "OtherAssessment" %>
-      </div>
+      <%= f.hidden_field :type, value: "OtherAssessment" %>
       <div class="row">
         <%= button_tag "Submit"%>
       </div>

--- a/app/views/outcomes/show.html.erb
+++ b/app/views/outcomes/show.html.erb
@@ -21,24 +21,22 @@
   <table id="direct_assessments">
     <tr>
       <th>Subject</th>
-      <th>Semester</th>
       <th>Assignment Name</th>
       <th>Assignment Description</th>
       <th>Minimum Grade</th>
       <th>Target Percentage</th>
-      <th>Actual Percentage</th>
+      <th></th>
       <th></th>
     </tr>
     <% @direct_assessments.each do |assessment| %>
       <tr id="direct_assessment-<%=assessment.id %>">
         <td><%= assessment.subject %></td>
-        <td><%= assessment.semester%></td>
-        <td><%= assessment.assignment_name%></td>
-        <td><%= assessment.assignment_description%></td>
-        <td><%= assessment.minimum_grade%></td>
-        <td><%= assessment.target_percentage%></td>
-        <td><%= assessment.actual_percentage%></td>
+        <td><%= assessment.name %></td>
+        <td><%= assessment.description %></td>
+        <td><%= assessment.minimum_grade %></td>
+        <td><%= assessment.target_percentage %></td>
         <td><%= link_to "Edit", edit_direct_assessment_path(assessment) %>
+        <td><%= link_to "View and add results", direct_assessment_path(assessment) %>
       </tr>
     <% end %>
   </table>
@@ -52,23 +50,21 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th>Year</th>
       <th>Minimum Category</th>
       <th>Target Percentage</th>
-      <th>Actual Percentage</th>
       <th>Type</th>
+      <th></th>
       <th></th>
     </tr>
     <% @indirect_assessments.each do |assessment| %>
       <tr id="indirect_assessment-<%=assessment.id %>">
-        <td><%= assessment.assessment_name%></td>
-        <td><%= assessment.assessment_description%></td>
-        <td><%= assessment.year%></td>
-        <td><%= assessment.minimum_category%></td>
-        <td><%= assessment.target_percentage%></td>
-        <td><%= assessment.actual_percentage%></td>
+        <td><%= assessment.name %></td>
+        <td><%= assessment.description %></td>
+        <td><%= assessment.minimum_category %></td>
+        <td><%= assessment.target_percentage %></td>
         <td><%= assessment_type(assessment) %></td>
         <td><%= link_to "Edit", edit_indirect_assessment_path(assessment) %></td>
+        <td><%= link_to "View and add results", indirect_assessment_path(assessment) %></td>
       </tr>
     <% end %>
   </table>

--- a/app/views/participations/_participation_form.html.erb
+++ b/app/views/participations/_participation_form.html.erb
@@ -6,7 +6,7 @@
           <%=f.label "Program Name", class: "left inline" %>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assessment_name, placeholder: "e.g. 'UROP'" %>
+          <%=f.text_field :name, placeholder: "e.g. 'UROP'" %>
         </div>
       </div>
       <div class="row">
@@ -14,15 +14,7 @@
           <%=f.label "Program Description", class: "left inline"%>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assessment_description, placeholder: "e.g. 'Undergraduate Research Projects'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%=f.label "Year", class: "left inline" %>
-        </div>
-        <div class="small-2 columns end">
-          <%=f.select :year, @available_years  %>
+          <%=f.text_field :description, placeholder: "e.g. 'Undergraduate Research Projects'" %>
         </div>
       </div>
       <div class="row">
@@ -33,15 +25,7 @@
           <%=f.text_field :target_percentage, placeholder: "Whole number, e.g. '80' for '80%'" %>
         </div>
       </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%=f.label "Actual Participation Percentage", class: "left inline" %>
-        </div>
-        <div class="small-4 columns end">
-          <%=f.text_field :actual_percentage, placeholder:  "Whole number, e.g. '80' for '80%'" %>
-        </div>
-        <%= f.hidden_field :type, value: "Participation" %>
-      </div>
+      <%= f.hidden_field :type, value: "Participation" %>
       <div class="row">
         <%= button_tag "Submit"%>
       </div>

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -1,4 +1,4 @@
-<h3>Add a new result for <%= @assessment.assignment_name %></h3>
+<h3>Add a new result for <%= @assessment.name %></h3>
 
 <%= form_for [@assessment, @result] do |f| %>
   <%= f.label "Year" %>

--- a/app/views/surveys/_survey_form.html.erb
+++ b/app/views/surveys/_survey_form.html.erb
@@ -6,7 +6,7 @@
           <%=f.label "Survey Name", class: "left inline" %>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assessment_name, placeholder: "e.g. 'Senior Survey'" %>
+          <%=f.text_field :name, placeholder: "e.g. 'Senior Survey'" %>
         </div>
       </div>
       <div class="row">
@@ -14,7 +14,7 @@
           <%=f.label "Survey Description", class: "left inline"%>
         </div>
         <div class="small-6 columns end">
-          <%=f.text_field :assessment_description, placeholder: "e.g. 'Biennial survey administered to graduating seniors'" %>
+          <%=f.text_field :description, placeholder: "e.g. 'Biennial survey administered to graduating seniors'" %>
         </div>
       </div>
       <div class="row">
@@ -23,14 +23,6 @@
         </div>
         <div class="small-6 columns end">
           <%=f.text_field :survey_question, :placeholder => "e.g. 'How satisfied are you with advising in your major?'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%=f.label "Year", class: "left inline" %>
-        </div>
-        <div class="small-2 columns end">
-          <%=f.select :year, @available_years  %>
         </div>
       </div>
       <div class="row">
@@ -49,15 +41,7 @@
           <%=f.text_field :target_percentage, placeholder: "Whole number, e.g. '80' for '80%'" %>
         </div>
       </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%=f.label "Actual Percentage", class: "left inline" %>
-        </div>
-        <div class="small-4 columns end">
-          <%=f.text_field :actual_percentage, placeholder:  "Whole number, e.g. '80' for '80%'" %>
-        </div>
-        <%= f.hidden_field :type, value: "Survey" %>
-      </div>
+      <%= f.hidden_field :type, value: "Survey" %>
       <div class="row">
         <%= button_tag "Submit"%>
       </div>

--- a/db/migrate/20150609192402_rename_assessment_fields.rb
+++ b/db/migrate/20150609192402_rename_assessment_fields.rb
@@ -1,0 +1,9 @@
+class RenameAssessmentFields < ActiveRecord::Migration
+  def change
+    rename_column :direct_assessments, :assignment_name, :name
+    rename_column :direct_assessments, :assignment_description, :description
+
+    rename_column :indirect_assessments, :assessment_name, :name
+    rename_column :indirect_assessments, :assessment_description, :description
+  end
+end

--- a/db/migrate/20150609194758_remove_percentage_year_semester_from_assessments.rb
+++ b/db/migrate/20150609194758_remove_percentage_year_semester_from_assessments.rb
@@ -1,0 +1,9 @@
+class RemovePercentageYearSemesterFromAssessments < ActiveRecord::Migration
+  def change
+    remove_column :direct_assessments, :actual_percentage, :integer
+    remove_column :direct_assessments, :semester, :string
+
+    remove_column :indirect_assessments, :actual_percentage, :integer
+    remove_column :indirect_assessments, :year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609170601) do
+ActiveRecord::Schema.define(version: 20150609194758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,33 +37,29 @@ ActiveRecord::Schema.define(version: 20150609170601) do
   add_index "departments", ["slug"], name: "index_departments_on_slug", unique: true, using: :btree
 
   create_table "direct_assessments", force: :cascade do |t|
-    t.string   "semester"
-    t.string   "assignment_name"
-    t.string   "assignment_description"
+    t.string   "name"
+    t.string   "description"
     t.string   "problem_description"
     t.string   "minimum_grade"
     t.integer  "target_percentage"
-    t.integer  "actual_percentage"
     t.integer  "outcome_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "subject_id",             null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.integer  "subject_id",          null: false
   end
 
   add_index "direct_assessments", ["subject_id"], name: "index_direct_assessments_on_subject_id", using: :btree
 
   create_table "indirect_assessments", force: :cascade do |t|
-    t.string   "assessment_name"
-    t.string   "assessment_description"
+    t.string   "name"
+    t.string   "description"
     t.string   "survey_question"
-    t.integer  "year"
     t.string   "minimum_category"
     t.integer  "target_percentage"
-    t.integer  "actual_percentage"
     t.integer  "outcome_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "type",                   null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.string   "type",              null: false
   end
 
   create_table "outcome_alignments", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,25 +18,21 @@ FactoryGirl.define do
   end
 
   factory :direct_assessment do
-    actual_percentage 82
-    assignment_description "Integration"
-    assignment_name "Problem Set 1"
+    description "Integration"
     minimum_grade "7 points out of 10"
+    name "Problem Set 1"
     outcome
     problem_description "Question 3, Integration by parts"
-    semester "2015FA"
     subject
     target_percentage 80
   end
 
   factory :other_assessment do
-    actual_percentage 78
-    assessment_description "Senior Thesis Completion"
-    assessment_name "Percent of students who complete a senior thesis"
+    description "Senior Thesis Completion"
+    name "Percent of students who complete a senior thesis"
     outcome
     target_percentage 80
     type "OtherAssessment"
-    year 2014
   end
 
   factory :outcome do
@@ -46,13 +42,11 @@ FactoryGirl.define do
   end
 
   factory :participation do
-    actual_percentage 78
-    assessment_description "Undergraduation Research Project"
-    assessment_name "UROP"
+    description "Undergraduation Research Project"
+    name "UROP"
     outcome
     target_percentage 80
     type "Participation"
-    year 2014
   end
 
   factory :standard_outcome do
@@ -66,15 +60,13 @@ FactoryGirl.define do
   end
 
   factory :survey do
-    actual_percentage 78
-    assessment_description "Biennial survey administered to graduating seniors"
-    assessment_name "Senior Survey"
+    description "Biennial survey administered to graduating seniors"
     minimum_category "Somewhat satisfied"
+    name "Senior Survey"
     outcome
     survey_question "How satisfied are you with advising in your major?"
     target_percentage 80
     type "Survey"
-    year 2014
   end
 
   factory :user do

--- a/spec/features/user_creates_a_result_spec.rb
+++ b/spec/features/user_creates_a_result_spec.rb
@@ -1,11 +1,15 @@
 require "rails_helper"
 
 feature "User creates a result" do
-  scenario "and it is associated with an assessment" do
+  scenario "and it is associated with a direct assessment" do
     assessment = create(:direct_assessment)
     user = user_with_admin_access_to(assessment.department)
 
-    visit direct_assessment_path(assessment, as: user)
+    visit outcome_path(assessment.outcome, as: user)
+
+    within("#direct_assessment-#{assessment.id}") do
+      click_on "View and add results"
+    end
 
     click_on "Add result"
 
@@ -20,5 +24,28 @@ feature "User creates a result" do
     expect(page).to have_content "Problem Set 2"
     expect(page).to have_content "Polynomial Equations"
     expect(page).to have_content "72"
+  end
+
+  scenario "and it is associated with an indirect assessment" do
+    assessment = create(:survey)
+    user = user_with_admin_access_to(assessment.department)
+
+    visit outcome_path(assessment.outcome, as: user)
+
+    within("#indirect_assessment-#{assessment.id}") do
+      click_on "View and add results"
+    end
+
+    click_on "Add result"
+
+    select "2015", from: "result_year"
+    fill_in "result_assessment_name", with: "Senior Survey"
+    fill_in "result_assessment_description", with: "Annual survey"
+    fill_in "result_percentage", with: "92"
+    click_on "Submit"
+
+    expect(page).to have_content "Senior Survey"
+    expect(page).to have_content "Annual survey"
+    expect(page).to have_content "92"
   end
 end

--- a/spec/features/user_creates_direct_assessment_spec.rb
+++ b/spec/features/user_creates_direct_assessment_spec.rb
@@ -36,12 +36,11 @@ feature "User creates an assessment" do
 
   def fill_and_submit_form
     select first("#direct_assessment_subject_id option").text, from: "direct_assessment_subject_id"
-    fill_in "direct_assessment_assignment_name", with: "Problem Set 1"
-    fill_in "direct_assessment_assignment_description", with: "Integration"
+    fill_in "direct_assessment_name", with: "Problem Set 1"
+    fill_in "direct_assessment_description", with: "Integration"
     fill_in "direct_assessment_problem_description", with: "Integration by parts"
     fill_in "direct_assessment_minimum_grade", with: "7/10"
     fill_in "direct_assessment_target_percentage", with: 80
-    fill_in "direct_assessment_actual_percentage", with: 78
     click_on "Submit"
   end
 end

--- a/spec/features/user_creates_other_assessment_spec.rb
+++ b/spec/features/user_creates_other_assessment_spec.rb
@@ -21,10 +21,9 @@ feature "User creates other assessment" do
   end
 
   def fill_and_submit_form
-    fill_in "indirect_assessment_assessment_name", with: "Senior Thesis Completion"
-    fill_in "indirect_assessment_assessment_description", with: "Percent of students who complete"
+    fill_in "indirect_assessment_name", with: "Senior Thesis Completion"
+    fill_in "indirect_assessment_description", with: "Percent of students who complete"
     fill_in "indirect_assessment_target_percentage", with: 80
-    fill_in "indirect_assessment_actual_percentage", with: 78
     click_on "Submit"
   end
 end

--- a/spec/features/user_creates_participation_spec.rb
+++ b/spec/features/user_creates_participation_spec.rb
@@ -21,10 +21,9 @@ feature "User creates a participation assessment" do
   end
 
   def fill_and_submit_form
-    fill_in "indirect_assessment_assessment_name", with: "UROP"
-    fill_in "indirect_assessment_assessment_description", with: "Undergraduate Resarch Projects"
+    fill_in "indirect_assessment_name", with: "UROP"
+    fill_in "indirect_assessment_description", with: "Undergraduate Resarch Projects"
     fill_in "indirect_assessment_target_percentage", with: 80
-    fill_in "indirect_assessment_actual_percentage", with: 78
     click_on "Submit"
   end
 end

--- a/spec/features/user_creates_survey_spec.rb
+++ b/spec/features/user_creates_survey_spec.rb
@@ -21,12 +21,11 @@ feature "User creates a survey assessment" do
   end
 
   def fill_and_submit_form
-    fill_in "indirect_assessment_assessment_name", with: "Senior Survey"
-    fill_in "indirect_assessment_assessment_description", with: "Biennial indirect_assessment"
+    fill_in "indirect_assessment_name", with: "Senior Survey"
+    fill_in "indirect_assessment_description", with: "Biennial survey"
     fill_in "indirect_assessment_survey_question", with: "How satisfied are you?"
     fill_in "indirect_assessment_minimum_category", with: "Somewhat satisfied"
     fill_in "indirect_assessment_target_percentage", with: 80
-    fill_in "indirect_assessment_actual_percentage", with: 78
     click_on "Submit"
   end
 end

--- a/spec/features/user_updates_other_assessment_spec.rb
+++ b/spec/features/user_updates_other_assessment_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "User updates other assessment" do
   scenario "other assessment is successfully updated" do
-    assessment = create(:other_assessment, assessment_name: "Senior Thesis")
+    assessment = create(:other_assessment, name: "Senior Thesis")
     outcome = assessment.outcome
     user = user_with_admin_access_to(outcome.course.department)
 
@@ -12,7 +12,7 @@ feature "User updates other assessment" do
       click_on "Edit"
     end
 
-    fill_in "indirect_assessment_assessment_name", with: "Freshman Thesis"
+    fill_in "indirect_assessment_name", with: "Freshman Thesis"
     click_on "Submit"
 
     within("#indirect_assessments") do

--- a/spec/features/user_updates_participation_spec.rb
+++ b/spec/features/user_updates_participation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "User updates a participation assessment" do
   scenario "a participation assessment is successfully updated" do
-    assessment = create(:participation, assessment_name: "UROP")
+    assessment = create(:participation, name: "UROP")
     outcome = assessment.outcome
     user = user_with_admin_access_to(outcome.course.department)
 
@@ -12,7 +12,7 @@ feature "User updates a participation assessment" do
       click_on "Edit"
     end
 
-    fill_in "indirect_assessment_assessment_name", with: "POUR"
+    fill_in "indirect_assessment_name", with: "POUR"
     click_on "Submit"
 
     within("#indirect_assessments") do

--- a/spec/features/user_updates_survey_spec.rb
+++ b/spec/features/user_updates_survey_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "User updates a survey assessment" do
   scenario "a survey assessment is successfully updated" do
-    assessment = create(:survey, assessment_name: "Senior Survey")
+    assessment = create(:survey, name: "Senior Survey")
     outcome = assessment.outcome
     user = user_with_admin_access_to(outcome.course.department)
 
@@ -12,7 +12,7 @@ feature "User updates a survey assessment" do
       click_on "Edit"
     end
 
-    fill_in "indirect_assessment_assessment_name", with: "Freshman Survey"
+    fill_in "indirect_assessment_name", with: "Freshman Survey"
     click_on "Submit"
 
     within("#indirect_assessments") do


### PR DESCRIPTION
* Remove prefixes on name and description fields in the
  direct_assessments and indirect_assessments tables

* Remove columns from direct and indirect assessments that are now in
* the results table