### PR TITLE
Raise on unpermitted params in dev and test

### DIFF
--- a/app/controllers/indirect_assessments_controller.rb
+++ b/app/controllers/indirect_assessments_controller.rb
@@ -47,7 +47,9 @@ class IndirectAssessmentsController < ApplicationController
     params.require(:indirect_assessment).permit(
       :actual_percentage,
       :description,
+      :minimum_category,
       :name,
+      :survey_question,
       :target_percentage,
       :type,
       :year

--- a/app/controllers/outcomes_controller.rb
+++ b/app/controllers/outcomes_controller.rb
@@ -38,6 +38,6 @@ class OutcomesController < ApplicationController
   private
 
   def outcome_params
-    params.require(:outcome).permit(:name,:description)
+    params.require(:outcome).permit(:name, :course_id, :description)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,17 +16,7 @@ Bundler.require(*Rails.groups)
 module Abet
   class Application < Rails::Application
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.middleware.use Rack::Deflater
   end
   RolesDb.configure do |config|
     config.ssl_cert_key_file = Rails.root.join("config", "certs", "outcomes-key.pem")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,8 @@ Rails.application.configure do
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
+  # Raises on unpermitted params
+  config.action_controller.action_on_unpermitted_parameters = :raise
 end
 
 RolesDb.configure do |config|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,4 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.roles_strategy = 'RolesDbAccess'
-
-  #added for Foundation Zurb
-  config.assets.precompile += %w( vendor/modernizr.js )
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Allow easy faked sign in in test
   config.middleware.use TouchstoneBackDoor
+
+  # Raises on unpermitted params
+  config.action_controller.action_on_unpermitted_parameters = :raise
 end


### PR DESCRIPTION
This is a typical part of our setup from [suspenders] and helps us catch
missing permitted parameters early. Adding this configuration showed us
a couple of places where we were not permitting the right attributes.