### PR TITLE
Centralize RolesDB config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,12 +19,4 @@ module Abet
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
     config.middleware.use Rack::Deflater
   end
-  RolesDb.configure do |config|
-    config.ssl_cert_key_file = Rails.root.join("config", "certs", "outcomes-key.pem")
-    config.ssl_cert_file = Rails.root.join("config", "certs", "outcomes.cer")
-    config.ssl_ca_cert_file = Rails.root.join("config", "certs", "mit.pem")
-    config.roles_wsdl_file = Rails.root.join("config", "certs", "roles.wsdl")
-    config.ssl_cert_key_password = "abetiscool"
-    config.proxy_user_name = 'abetuser'
-  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,11 +38,3 @@ Rails.application.configure do
   # Raises on unpermitted params
   config.action_controller.action_on_unpermitted_parameters = :raise
 end
-
-RolesDb.configure do |config|
-  config.strategy_class = 'RolesDb::Roles'
-  config.mocked_account_list_file = Rails.root.join('config', 'dev-roles.yaml')
-end
-
-ENV['eppn'] ||= "daries@mit.edu"
-

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  config.roles_strategy = 'RolesDbAccess'
 end

--- a/config/initializers/roles_db.rb
+++ b/config/initializers/roles_db.rb
@@ -13,3 +13,12 @@ if Rails.env.test?
     config.strategy_class = "RolesDb::LocalRoles"
   end
 end
+
+RolesDb.configure do |config|
+  config.ssl_cert_key_file = Rails.root.join("config", "certs", "outcomes-key.pem")
+  config.ssl_cert_file = Rails.root.join("config", "certs", "outcomes.cer")
+  config.ssl_ca_cert_file = Rails.root.join("config", "certs", "mit.pem")
+  config.roles_wsdl_file = Rails.root.join("config", "certs", "roles.wsdl")
+  config.ssl_cert_key_password = "abetiscool"
+  config.proxy_user_name = "abetuser"
+end


### PR DESCRIPTION
Roles DB configuration was still present in the application
configuration when most of it had been moved to an initializer. I moved
it all to the initializer.