### PR TITLE
Remove reference to modernizr

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,4 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.roles_strategy = 'RolesDbAccess'
-
-  #added for Foundation Zurb
-  config.assets.precompile += %w( vendor/modernizr.js )
 end


### PR DESCRIPTION
This file doesn't actually exist on the file system and is not needed
any longer anyway. No need to try to precompile it.