### PR TITLE
Display unaligned standard outcomes for courses with no alignments

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -10,12 +10,6 @@ class CoursesController < ApplicationController
 
   def retrieve_unassociated_outcomes
     return [] unless @course.has_custom_outcomes?
-    standard_ids = @course.outcomes.map do |outcome|
-      outcome.outcome_alignments.map do |alignment|
-        alignment.standard_outcome_id
-      end.flatten
-    end.flatten.uniq
-    return [] if standard_ids.count == 0
-    return StandardOutcome.where.not(id: standard_ids)
+    StandardOutcome.unaligned_with(@course)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,10 +2,6 @@ class Course < ActiveRecord::Base
   belongs_to :department
   has_many :outcomes
 
-  def has_custom_outcomes?
-    self.has_custom_outcomes
-  end
-
   def adopt_default_outcomes!
     update_attribute(:has_custom_outcomes, false)
     defaults = StandardOutcome.retrieve_defaults || []

--- a/app/models/standard_outcome.rb
+++ b/app/models/standard_outcome.rb
@@ -18,4 +18,12 @@ class StandardOutcome < ActiveRecord::Base
   def self.retrieve_defaults
     self.all
   end
+
+  def self.aligned_with(course)
+    joins(outcome_alignments: { outcome: :course }).where(courses: { id: course })
+  end
+
+  def self.unaligned_with(course)
+    where.not(id: aligned_with(course))
+  end
 end

--- a/app/views/outcomes/match_to_standard.html.erb
+++ b/app/views/outcomes/match_to_standard.html.erb
@@ -1,31 +1,31 @@
 <div class="row">
-	<h3>Match outcome to ABET default outcomes</h3>
+<h3>Match outcome to ABET default outcomes</h3>
 </div>
 <div class="row">
-	<h4><%=@outcome.name%>.&nbsp;<%=@outcome.description%></h4>
+  <h4><%=@outcome.name%>. <%=@outcome.description%></h4>
 </div>
 <div class="row">
-	<div class="small-10">
-		<% form_for @outcome do |f| %>
-			<% @std_outcome_alignments.each do |std_outcome_alignment| %>
-				<div class="row">
-					<div class="small-1 columns">
-						<%std_outcome_alignment.standard_outcome.name%>
-					</div>
-					<div class="small-1 columns">
-						<%std_outcome_alignment.standard_outcome.description%>
-					</div>
-				</div>
-				<%= f.fields_for :outcome_alignments do |align_form| %>
-				<div class="row">
-					<div class="small-2 columns">
-						<%=align_form.select :alignment_level, options_for_select(@align_levels)%>
-					</div>
-				</div>
-				<% end %>
-			<% end %>
-		<% end %>
-		</div>
-	</div>
+  <div class="small-10">
+    <% form_for @outcome do |f| %>
+      <% @std_outcome_alignments.each do |std_outcome_alignment| %>
+        <div class="row">
+          <div class="small-1 columns">
+            <%std_outcome_alignment.standard_outcome.name%>
+          </div>
+          <div class="small-1 columns">
+            <%std_outcome_alignment.standard_outcome.description%>
+          </div>
+        </div>
+        <%= f.fields_for :outcome_alignments do |align_form| %>
+          <div class="row">
+            <div class="small-2 columns">
+              <%=align_form.select :alignment_level, options_for_select(@align_levels)%>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
 </div>
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,6 +41,12 @@ FactoryGirl.define do
     course
   end
 
+  factory :outcome_alignment do
+    alignment_level "Moderate alignment"
+    outcome
+    standard_outcome
+  end
+
   factory :participation do
     description "Undergraduation Research Project"
     name "UROP"

--- a/spec/models/standard_outcome_spec.rb
+++ b/spec/models/standard_outcome_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe StandardOutcome do
+  describe ".aligned_with" do
+    it "returns standard outcomes aligned with a course" do
+      course = create(:course)
+      outcome = create(:outcome, course: course)
+      standard_outcome = create(:outcome_alignment, outcome: outcome).standard_outcome
+
+      expect(StandardOutcome.aligned_with(course)).to eq [standard_outcome]
+    end
+  end
+
+  describe ".unaligned_with" do
+    it "returns standard outcomes not aligned with a course" do
+      course = create(:course)
+      outcome = create(:outcome, course: course)
+      standard_outcome = create(:standard_outcome)
+      create(:outcome_alignment, outcome: outcome)
+
+      expect(StandardOutcome.unaligned_with(course)).to eq [standard_outcome]
+    end
+  end
+end


### PR DESCRIPTION
* Fixes bug reported in https://trello.com/c/fl0TlULZ
* Moves logic for finding unassociated standard outcomes from controller to model