### PR TITLE
Add current tab tracking

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,12 +1,5 @@
 class PagesController < ApplicationController
   include HighVoltage::StaticPage
 
-  before_action :skip_tabs
   skip_after_action :verify_authorized
-
-  private
-
-  def skip_tabs
-    @skip_tabs = true
-  end
 end

--- a/app/helpers/tab_helper.rb
+++ b/app/helpers/tab_helper.rb
@@ -1,0 +1,17 @@
+module TabHelper
+  OUTCOMES = :outcomes
+  ASSESSMENTS = :assessments
+  DATA_ENTRY = :data_entry
+
+  def tab(value)
+    @current_tab = value.to_sym
+  end
+
+  def tab_class(value)
+    if @current_tab == value.to_sym
+      "is-active"
+    else
+      ""
+    end
+  end
+end

--- a/app/views/application/_tabs.html.erb
+++ b/app/views/application/_tabs.html.erb
@@ -1,5 +1,17 @@
 <ul class="accordion-tabs-minimal" role="navigation">
-  <li><%= link_to t(".outcomes"), root_path, class: "is-active" %></li>
-  <li><%= link_to t(".assessments"), "javascript: void(0)" %></li>
-  <li><%= link_to t(".data"), "javascript: void(0)" %></li>
+  <li>
+    <%= link_to t(".outcomes"),
+      outcomes_dashboard_path,
+      class: tab_class(TabHelper::OUTCOMES) %>
+  </li>
+  <li>
+    <%= link_to t(".assessments"),
+      "javascript: void(0)",
+      class: tab_class(TabHelper::ASSESSMENTS) %>
+  </li>
+  <li>
+    <%= link_to t(".data"),
+      "javascript: void(0)",
+      class: tab_class(TabHelper::DATA_ENTRY) %>
+  </li>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
   <body class="<%= body_class %>">
     <%= render "navigation" %>
 
-    <% unless @skip_tabs %>
+    <% if @current_tab %>
       <%= render "tabs" %>
     <% end %>
 

--- a/app/views/outcomes_dashboard/show.html.erb
+++ b/app/views/outcomes_dashboard/show.html.erb
@@ -1,3 +1,5 @@
+<% tab(TabHelper::OUTCOMES) %>
+
 <h1><%= t(".heading") %></h1>
 
 <% if @outcomes_dashboard.courses_without_outcomes.present? %>


### PR DESCRIPTION
* Each top level view that wants to be displayed under tabs needs to
  declare which tab it is under by using the `tab` helper.
* The tabs are no longer displayed if there is no current tab.