### PR TITLE
Move outcome management pages to outcomes tab

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,3 +1,5 @@
+<% tab(TabHelper::OUTCOMES) %>
+
 <% if @outcomes.present? %>
   <%= render "outcomes",
     course: @course,

--- a/app/views/outcomes/new.html.erb
+++ b/app/views/outcomes/new.html.erb
@@ -1,2 +1,4 @@
+<% tab(TabHelper::OUTCOMES) %>
+
 <h1><%= t(".heading") %></h1>
 <%= render "form", outcome: @outcome %>


### PR DESCRIPTION
These are all pages you would be likely to view in the context of
managing outcomes.