### PR TITLE
Fix intermittently failing specs

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  sequence(:label) { |n| ("a".."z").to_a[n - 1] }
+  sequence(:label) { |n| ("a".."zzz").to_a[n - 1] }
   sequence(:name) { |n| "The #{n.ordinalize} Name" }
   sequence(:number) { |n| n.to_s }
 


### PR DESCRIPTION
When a label is generated more than 26 times (the number of letters in
the range provided to the label sequence) it starts creating outcomes
without names, which causes two specs to fail when more than 26 outcomes
have been created before the specs run. This change extends the size of
the range to 18278 so that should not happen anymore.