### PR TITLE
Refactor outcome adoption

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,16 +7,20 @@ class Course < ActiveRecord::Base
   end
 
   def adopt_default_outcomes!
-    update_attribute(:has_custom_outcomes, false)
-    defaults = StandardOutcome.retrieve_defaults || []
-    defaults.each do |outcome|
-      Outcome.create(name: outcome.name,
-        description: outcome.description,
-        course: self, standard_outcome_id: outcome.id)
+    self.class.transaction do
+      update_column(:has_custom_outcomes, false)
+
+      StandardOutcome.all.each do |standard_outcome|
+        outcomes.create!(
+          name: standard_outcome.name,
+          description: standard_outcome.description,
+          standard_outcome_id: standard_outcome.id
+        )
+      end
     end
   end
 
   def adopt_custom_outcomes!
-    update_attribute(:has_custom_outcomes, true)
+    update_column(:has_custom_outcomes, true)
   end
 end

--- a/app/models/standard_outcome.rb
+++ b/app/models/standard_outcome.rb
@@ -1,10 +1,6 @@
 class StandardOutcome < ActiveRecord::Base
   has_many :alignments
 
-  def self.retrieve_defaults
-    self.all
-  end
-
   def self.aligned_with(course)
     joins(alignments: { outcome: :course }).where(courses: { id: course })
   end


### PR DESCRIPTION
* There are multiple updates involved in adopting default outcomes, so
  they should occur inside a transaction.
* Use `update_column` rather than `update_attribute`. It will raise an
  exception if the SQL update fails where update_attribute may not.
* Remove `StandardOutcome.retreive_defaults` as it's analogous to
  `.all`.