### PR TITLE
Rename OutcomeAlignments to Alignments

### DIFF
--- a/app/controllers/outcomes_controller.rb
+++ b/app/controllers/outcomes_controller.rb
@@ -10,7 +10,7 @@ class OutcomesController < ApplicationController
     @outcome = course.outcomes.build
 
     StandardOutcome.all.each do |default_outcome|
-      @outcome.outcome_alignments.build(standard_outcome: default_outcome)
+      @outcome.alignments.build(standard_outcome: default_outcome)
     end
 
     authorize(@outcome)
@@ -44,9 +44,9 @@ class OutcomesController < ApplicationController
     params.require(:outcome).permit(
       :name,
       :description,
-      outcome_alignments_attributes: [
+      alignments_attributes: [
         :standard_outcome_id,
-        :alignment_level
+        :level
       ]
     )
   end

--- a/app/models/alignment.rb
+++ b/app/models/alignment.rb
@@ -1,4 +1,4 @@
-class OutcomeAlignment < ActiveRecord::Base
+class Alignment < ActiveRecord::Base
   LEVELS = ["Low alignment", "Moderate alignment", "High alignment"].freeze
 
   belongs_to :outcome

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -5,9 +5,9 @@ class Outcome < ActiveRecord::Base
   has_many :surveys
   has_many :participations
   has_many :other_assessments
-  has_many :outcome_alignments
-  accepts_nested_attributes_for :outcome_alignments,
-    reject_if: ->(attributes) { attributes[:alignment_level].blank? }
+  has_many :alignments
+  accepts_nested_attributes_for :alignments,
+    reject_if: ->(attributes) { attributes[:level].blank? }
 
   delegate :department, to: :course
 end

--- a/app/models/standard_outcome.rb
+++ b/app/models/standard_outcome.rb
@@ -1,12 +1,12 @@
 class StandardOutcome < ActiveRecord::Base
-  has_many :outcome_alignments
+  has_many :alignments
 
   def self.retrieve_defaults
     self.all
   end
 
   def self.aligned_with(course)
-    joins(outcome_alignments: { outcome: :course }).where(courses: { id: course })
+    joins(alignments: { outcome: :course }).where(courses: { id: course })
   end
 
   def self.unaligned_with(course)

--- a/app/views/outcomes/_form.html.erb
+++ b/app/views/outcomes/_form.html.erb
@@ -5,12 +5,12 @@
   <fieldset class="alignments">
     <legend><%= t(".alignments_legend") %></legend>
 
-    <%= f.simple_fields_for(:outcome_alignments) do |alignment_form| %>
+    <%= f.simple_fields_for(:alignments) do |alignment_form| %>
       <%= alignment_form.input :standard_outcome_id, as: :hidden %>
-      <%= alignment_form.input :alignment_level,
+      <%= alignment_form.input :level,
         label: alignment_form.object.standard_outcome,
         prompt: :translate,
-        collection: OutcomeAlignment::LEVELS %>
+        collection: Alignment::LEVELS %>
     <% end %>
   </fieldset>
 

--- a/app/views/outcomes/show.html.erb
+++ b/app/views/outcomes/show.html.erb
@@ -1,17 +1,17 @@
 <h3><%= @outcome.name %>: <%= @outcome.description %></h3>
-<% if @outcome.outcome_alignments.any? %>
+<% if @outcome.alignments.any? %>
   <h4>Aligned ABET Outcomes</h4>
-  <table width="1000" id="outcome_alignments">
+  <table width="1000" id="alignments">
     <tr>
       <th>Name</th>
       <th>Description</th>
       <th width="150">Alignment Level</th>
     </tr>
-    <% @outcome.outcome_alignments.each do |alignment| %>
+    <% @outcome.alignments.each do |alignment| %>
       <tr>
         <td><%= alignment.standard_outcome.name %></td>
         <td><%= alignment.standard_outcome.description %></td>
-        <td><%= alignment.alignment_level %></td>
+        <td><%= alignment.level %></td>
       </tr>
     <% end %>
   </table>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -12,5 +12,5 @@ en:
         description: e.g. 'The ability to apply engineering principles in a project context'
         name: e.g. '1.A'
     prompts:
-      outcome_alignments:
-        alignment_level: No alignment
+      alignments:
+        level: No alignment

--- a/db/migrate/20150612012532_rename_outcome_alignments.rb
+++ b/db/migrate/20150612012532_rename_outcome_alignments.rb
@@ -1,0 +1,6 @@
+class RenameOutcomeAlignments < ActiveRecord::Migration
+  def change
+    rename_table :outcome_alignments, :alignments
+    rename_column :alignments, :alignment_level, :level
+  end
+end

--- a/db/migrate/20150612013100_add_alignment_constraints.rb
+++ b/db/migrate/20150612013100_add_alignment_constraints.rb
@@ -1,0 +1,13 @@
+class AddAlignmentConstraints < ActiveRecord::Migration
+  def change
+    change_column_null :alignments, :outcome_id, false
+    change_column_null :alignments, :standard_outcome_id, false
+    change_column_null :alignments, :level, false
+
+    add_foreign_key :alignments, :outcomes
+    add_foreign_key :alignments, :standard_outcomes
+
+    add_index :alignments, [:outcome_id, :standard_outcome_id], unique: true
+    add_index :alignments, :standard_outcome_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150610184606) do
+ActiveRecord::Schema.define(version: 20150612013100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "alignments", force: :cascade do |t|
+    t.integer  "outcome_id",          null: false
+    t.integer  "standard_outcome_id", null: false
+    t.string   "level",               null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+  end
+
+  add_index "alignments", ["outcome_id", "standard_outcome_id"], name: "index_alignments_on_outcome_id_and_standard_outcome_id", unique: true, using: :btree
+  add_index "alignments", ["standard_outcome_id"], name: "index_alignments_on_standard_outcome_id", using: :btree
 
   create_table "courses", force: :cascade do |t|
     t.string   "number",                          null: false
@@ -65,14 +76,6 @@ ActiveRecord::Schema.define(version: 20150610184606) do
     t.string   "type",                null: false
   end
 
-  create_table "outcome_alignments", force: :cascade do |t|
-    t.integer  "outcome_id"
-    t.integer  "standard_outcome_id"
-    t.string   "alignment_level"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-  end
-
   create_table "outcomes", force: :cascade do |t|
     t.string   "name"
     t.string   "description"
@@ -120,6 +123,8 @@ ActiveRecord::Schema.define(version: 20150610184606) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
+  add_foreign_key "alignments", "outcomes"
+  add_foreign_key "alignments", "standard_outcomes"
   add_foreign_key "courses", "departments", on_delete: :restrict
   add_foreign_key "direct_assessments", "subjects"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -59,8 +59,8 @@ FactoryGirl.define do
     course
   end
 
-  factory :outcome_alignment do
-    alignment_level "Moderate alignment"
+  factory :alignment do
+    level "Moderate alignment"
     outcome
     standard_outcome
   end

--- a/spec/features/user_creates_custom_outcomes_spec.rb
+++ b/spec/features/user_creates_custom_outcomes_spec.rb
@@ -25,7 +25,7 @@ feature "User creates custom outcomes" do
 
     click_on "Details"
 
-    within("#outcome_alignments") do
+    within("#alignments") do
       expect(page).to have_content(associated_outcome.description)
       expect(page).to have_content("High alignment")
     end

--- a/spec/models/outcomes_dashboard_spec.rb
+++ b/spec/models/outcomes_dashboard_spec.rb
@@ -18,7 +18,7 @@ describe OutcomesDashboard do
       aligned_course = create(:course, has_custom_outcomes: true)
       create(:course, has_custom_outcomes: false)
       outcome = create(:outcome, course: aligned_course)
-      create(:outcome_alignment, outcome: outcome)
+      create(:alignment, outcome: outcome)
 
       dashboard = OutcomesDashboard.new(Course)
 

--- a/spec/models/standard_outcome_spec.rb
+++ b/spec/models/standard_outcome_spec.rb
@@ -5,7 +5,7 @@ describe StandardOutcome do
     it "returns standard outcomes aligned with a course" do
       course = create(:course)
       outcome = create(:outcome, course: course)
-      standard_outcome = create(:outcome_alignment, outcome: outcome).standard_outcome
+      standard_outcome = create(:alignment, outcome: outcome).standard_outcome
 
       expect(StandardOutcome.aligned_with(course)).to eq [standard_outcome]
     end
@@ -16,7 +16,7 @@ describe StandardOutcome do
       course = create(:course)
       outcome = create(:outcome, course: course)
       standard_outcome = create(:standard_outcome)
-      create(:outcome_alignment, outcome: outcome)
+      create(:alignment, outcome: outcome)
 
       expect(StandardOutcome.unaligned_with(course)).to eq [standard_outcome]
     end


### PR DESCRIPTION
There are no other types of alignments, so the `Outcome` prefix is
redundant. For similar reasons, the `alignment_level` field was renamed
`level`.

Data model constraints were also added.