### PR TITLE
Display default outcomes before adopting

### DIFF
--- a/app/controllers/default_outcomes_controller.rb
+++ b/app/controllers/default_outcomes_controller.rb
@@ -9,4 +9,10 @@ class DefaultOutcomesController < ApplicationController
       redirect_to course, error: t(".error")
     end
   end
+
+  def show
+    @outcomes = StandardOutcome.all
+    @course = Course.find(params[:course_id])
+    authorize(@course)
+  end
 end

--- a/app/views/courses/_interstitial.html.erb
+++ b/app/views/courses/_interstitial.html.erb
@@ -5,8 +5,7 @@
 
   <div class="row">
     <%=link_to "Adopt Default Outcomes",
-      course_default_outcomes_path(course),
-      method: :post %>
+      course_default_outcomes_path(course) %>
   </div>
 
   <div class="row">

--- a/app/views/default_outcomes/show.html.erb
+++ b/app/views/default_outcomes/show.html.erb
@@ -1,0 +1,11 @@
+<h1> Default Outcomes </h1>
+
+<ul>
+  <% @outcomes.each do |outcome| %>
+    <li><%= "#{outcome.name} - #{outcome.description}" %></li>
+  <% end %>
+<ul>
+
+<br>
+<%= button_to "Adopt default outcomes for Course #{@course.number} - #{@course.name}",
+  course_default_outcomes_path(@course) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   end
 
   resources :courses, only: [:show] do
-    resource :default_outcomes, only: [:create]
+    resource :default_outcomes, only: [:show, :create]
     resources :outcomes, only: [:new, :create]
   end
 

--- a/spec/features/user_adopts_standard_outcomes_for_course_spec.rb
+++ b/spec/features/user_adopts_standard_outcomes_for_course_spec.rb
@@ -11,5 +11,11 @@ feature "User adopts standard outcomes for a course" do
 
     expect(page).to have_content(standard_outcome.name)
     expect(page).to have_content(standard_outcome.description)
+
+    click_on "Adopt"
+
+    expect(page).to have_content "Default outcomes successfully adopted."
+    expect(page).to have_content(standard_outcome.name)
+    expect(page).to have_content(standard_outcome.description)
   end
 end


### PR DESCRIPTION
https://trello.com/c/eSZ6YpCC

Add default_outcomes#show page so that users can review the standard
outcomes before adopting them for a course.