### PR TITLE
Adopt standard outcomes via outcomes dashboard

### DIFF
--- a/app/views/outcomes_dashboard/_without_outcomes_actions.html.erb
+++ b/app/views/outcomes_dashboard/_without_outcomes_actions.html.erb
@@ -1,5 +1,2 @@
-<%= link_to t(".adopt_default"),
-  course_default_outcomes_path(course),
-  method: :post,
-  data: { confirm: t(".adopt_default_confirm") } %>
+<%= link_to t(".adopt_default"), course_default_outcomes_path(course) %>
 <%= link_to t(".create_custom"), new_course_outcome_path(course) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,6 @@ en:
       edit_outcomes: Edit Outcomes
     without_outcomes_actions:
       adopt_default: Adopt Default Outcomes
-      adopt_default_confirm: Are you sure?
       create_custom: Create Custom Outcome
   results:
     create: Result created successfully.

--- a/spec/features/admin_adopts_standard_outcomes_for_course_spec.rb
+++ b/spec/features/admin_adopts_standard_outcomes_for_course_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-feature "User adopts standard outcomes for a course" do
-  scenario "successfully" do
+feature "Admin adopts standard outcomes for a course" do
+  scenario "en masse" do
     course = create(:course)
     standard_outcome = create(:standard_outcome)
     user = user_with_admin_access_to(course.department)
 
-    visit course_path(course, as: user)
+    visit outcomes_dashboard_path(course, as: user)
     click_on "Adopt Default Outcomes"
 
     expect(page).to have_content(standard_outcome.name)


### PR DESCRIPTION
This test used to go through the course show page, which will likely be
going away as the admin section of the site is finished up today. The
workflow for adopting custom outcomes should be triggered from the
outcomes dashboard.