### PR TITLE
Create alignments for standard outcomes

### DIFF
--- a/app/models/alignment.rb
+++ b/app/models/alignment.rb
@@ -1,5 +1,8 @@
 class Alignment < ActiveRecord::Base
-  LEVELS = ["Low alignment", "Moderate alignment", "High alignment"].freeze
+  LOW = "Low alignment".freeze
+  MODERATE = "Moderate alignment".freeze
+  HIGH = "High alignment".freeze
+  LEVELS = [LOW, MODERATE, HIGH].freeze
 
   belongs_to :outcome
   belongs_to :standard_outcome

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,21 +2,18 @@ class Course < ActiveRecord::Base
   belongs_to :department
   has_many :outcomes
 
-  def self.with_custom_outcomes
-    where(has_custom_outcomes: true)
+  def self.without_outcomes
+    where(outcomes_count: 0)
+  end
+
+  def self.with_outcomes
+    where.not(outcomes_count: 0)
   end
 
   def adopt_default_outcomes!
     self.class.transaction do
       update_column(:has_custom_outcomes, false)
-
-      StandardOutcome.all.each do |standard_outcome|
-        outcomes.create!(
-          name: standard_outcome.name,
-          description: standard_outcome.description,
-          standard_outcome_id: standard_outcome.id
-        )
-      end
+      Adoption.process(StandardOutcome.all, course: self)
     end
   end
 

--- a/app/models/outcomes_dashboard.rb
+++ b/app/models/outcomes_dashboard.rb
@@ -4,11 +4,11 @@ class OutcomesDashboard
   end
 
   def courses_without_outcomes
-    courses.where(outcomes_count: 0)
+    courses.without_outcomes
   end
 
   def unaligned_courses
-    @unaligned_courses ||= courses.with_custom_outcomes.select do |course|
+    @unaligned_courses ||= courses.with_outcomes.select do |course|
       StandardOutcome.unaligned_with(course).any?
     end
   end

--- a/app/services/adoption.rb
+++ b/app/services/adoption.rb
@@ -1,0 +1,30 @@
+class Adoption
+  def self.process(adoptable_outcomes, course:)
+    new(adoptable_outcomes, course: course).process
+  end
+
+  def initialize(adoptable_outcomes, course:)
+    @adoptable_outcomes = Array.wrap(adoptable_outcomes)
+    @course = course
+  end
+
+  def process
+    adoptable_outcomes.each do |adoptable_outcome|
+      outcome = course.outcomes.build(
+        name: adoptable_outcome.name,
+        description: adoptable_outcome.description
+      )
+
+      outcome.alignments.build(
+        level: Alignment::HIGH,
+        standard_outcome_id: adoptable_outcome.id
+      )
+
+      outcome.save!
+    end
+  end
+
+  private
+
+  attr_reader :adoptable_outcomes, :course
+end

--- a/db/migrate/20150615155716_remove_standard_outcome_id_from_outcomes.rb
+++ b/db/migrate/20150615155716_remove_standard_outcome_id_from_outcomes.rb
@@ -1,0 +1,5 @@
+class RemoveStandardOutcomeIdFromOutcomes < ActiveRecord::Migration
+  def change
+    remove_column :outcomes, :standard_outcome_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150612013100) do
+ActiveRecord::Schema.define(version: 20150615155716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,9 +80,8 @@ ActiveRecord::Schema.define(version: 20150612013100) do
     t.string   "name"
     t.string   "description"
     t.integer  "course_id"
-    t.integer  "standard_outcome_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "results", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,6 +16,17 @@ FactoryGirl.define do
         create(:outcome, course: course)
       end
     end
+
+    trait :fully_aligned do
+      after(:create) do |course|
+        outcome = create(:outcome, course: course)
+        standard_outcomes = StandardOutcome.all.presence || [create(:standard_outcome)]
+
+        standard_outcomes.each do |standard_outcome|
+          create(:alignment, outcome: outcome, standard_outcome: standard_outcome)
+        end
+      end
+    end
   end
 
   factory :department do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,12 +1,43 @@
 require "rails_helper"
 
 describe Course do
-  describe ".with_custom_outcomes" do
-    it "finds courses that have custom outcomes" do
-      course = create(:course, has_custom_outcomes: true)
-      create(:course, has_custom_outcomes: false)
+  describe ".with_outcomes" do
+    it "finds courses that have outcomes" do
+      course = create(:outcome).course
+      create(:course)
 
-      expect(Course.with_custom_outcomes).to eq [course]
+      expect(Course.with_outcomes).to eq [course]
+    end
+  end
+
+  describe ".without_outcomes" do
+    it "finds courses that do not have outcomes" do
+      course = create(:course)
+      create(:outcome)
+
+      expect(Course.without_outcomes).to eq [course]
+    end
+  end
+
+  describe "#adopt_default_outcomes!" do
+    it "sets has_custom_outcomes to false" do
+      course = create(:course, has_custom_outcomes: true)
+
+      course.adopt_default_outcomes!
+
+      expect(course).not_to have_custom_outcomes
+    end
+
+    it "Adopts all standard outcomes" do
+      course = create(:course)
+      standard_outcomes = double("Standard Outcomes")
+      allow(StandardOutcome).to receive(:all).and_return(standard_outcomes)
+      allow(Adoption).to receive(:process)
+
+      course.adopt_default_outcomes!
+
+      expect(Adoption).to have_received(:process).
+        with(standard_outcomes, course: course)
     end
   end
 end

--- a/spec/models/outcomes_dashboard_spec.rb
+++ b/spec/models/outcomes_dashboard_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe OutcomesDashboard do
   describe "#courses_without_outcomes" do
     it "returns courses without any outcomes" do
-      course = create(:course)
-      create(:outcome)
+      course = double("Course")
+      allow(Course).to receive(:without_outcomes).and_return([course])
 
       dashboard = OutcomesDashboard.new(Course)
 
@@ -13,12 +13,10 @@ describe OutcomesDashboard do
   end
 
   describe "#unaligned_courses" do
-    it "returns courses that are not fully aligned" do
-      unaligned_course = create(:course, has_custom_outcomes: true)
-      aligned_course = create(:course, has_custom_outcomes: true)
-      create(:course, has_custom_outcomes: false)
-      outcome = create(:outcome, course: aligned_course)
-      create(:alignment, outcome: outcome)
+    it "returns courses with outcomes and that are not fully aligned" do
+      unaligned_course = create(:course, :with_unaligned_outcome)
+      create(:course, :fully_aligned)
+      create(:course)
 
       dashboard = OutcomesDashboard.new(Course)
 

--- a/spec/services/adoption_spec.rb
+++ b/spec/services/adoption_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Adoption do
+  it "creates highly aligned outcomes associated to the course" do
+    standard_outcome = create(:standard_outcome)
+    course = create(:course)
+
+    Adoption.process(standard_outcome, course: course)
+    alignment = Alignment.find_by(
+      standard_outcome_id: standard_outcome.id,
+      level: Alignment::HIGH
+    )
+
+    expect(course.outcomes.size).to eq 1
+    expect(course.outcomes.first.to_s).to eq standard_outcome.to_s
+    expect(alignment).to be_present
+  end
+end


### PR DESCRIPTION
Previously, adopted standard outcomes were implicitly aligned with
standard outcome from which they were derived. This was a needless
special-casing of the standard outcomes and started to cause problem
when implementing a mix of standard and custom outcomes on a single
course.