### PR TITLE
Introduce join table between outcomes and assessments

### DIFF
--- a/app/controllers/direct_assessments_controller.rb
+++ b/app/controllers/direct_assessments_controller.rb
@@ -4,15 +4,15 @@ class DirectAssessmentsController < ApplicationController
   def new
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = @outcome.direct_assessments.build
-    authorize(@assessment)
+    authorize(@outcome)
   end
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
-    @direct_assessment = @outcome.direct_assessments.build(direct_assessment_params)
-    authorize(@direct_assessment)
+    @assessment = @outcome.direct_assessments.build(direct_assessment_params.merge(department_id: @outcome.department.id))
+    authorize(@outcome)
 
-    if @direct_assessment.save
+    if @outcome.save
       redirect_to outcome_path(@outcome), success: t(".success")
     else
       render :new
@@ -30,7 +30,7 @@ class DirectAssessmentsController < ApplicationController
 
     @assessment.assign_attributes(direct_assessment_params)
     if @assessment.save
-      redirect_to outcome_path(@assessment.outcome)
+      redirect_to outcome_path(@assessment.outcomes.first), success: t(".success")
     else
       render :edit, success: t(".success")
     end
@@ -46,6 +46,7 @@ class DirectAssessmentsController < ApplicationController
   def direct_assessment_params
     params.require(:direct_assessment).permit(
       :actual_percentage,
+      :department_id,
       :description,
       :minimum_requirement,
       :name,

--- a/app/controllers/indirect_assessments_controller.rb
+++ b/app/controllers/indirect_assessments_controller.rb
@@ -4,15 +4,15 @@ class IndirectAssessmentsController < ApplicationController
   def new
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = @outcome.indirect_assessments.build(type: params[:type])
-    authorize(@assessment)
+    authorize(@outcome)
   end
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
-    @assessment = @outcome.indirect_assessments.build(assessment_params)
-    authorize(@assessment)
+    @assessment = @outcome.indirect_assessments.build(assessment_params.merge(department_id: @outcome.department.id))
+    authorize(@outcome)
 
-    if @assessment.save
+    if @outcome.save
       redirect_to outcome_path(@outcome), success: t(".success")
     else
       render :new
@@ -30,7 +30,7 @@ class IndirectAssessmentsController < ApplicationController
     authorize(@assessment)
 
     if @assessment.save
-      redirect_to outcome_path(@assessment.outcome), success: t(".success")
+      redirect_to outcome_path(@assessment.outcomes.first), success: t(".success")
     else
       render :edit
     end

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,7 +1,8 @@
 class DirectAssessment < ActiveRecord::Base
-  belongs_to :outcome
+  has_many :outcome_assessments, as: :assessment
+  has_many :outcomes, through: :outcome_assessments
+
+  belongs_to :department
   belongs_to :subject
   has_many :results, as: :assessment
-
-  delegate :department, to: :outcome
 end

--- a/app/models/indirect_assessment.rb
+++ b/app/models/indirect_assessment.rb
@@ -1,6 +1,8 @@
 class IndirectAssessment < ActiveRecord::Base
-  belongs_to :outcome
+  has_many :outcome_assessments, as: :assessment
+  has_many :outcomes, through: :outcome_assessments
+
   has_many :results, as: :assessment
 
-  delegate :department, to: :outcome
+  belongs_to :department
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,10 +1,10 @@
 class Outcome < ActiveRecord::Base
   belongs_to :course, counter_cache: true
-  has_many :direct_assessments
-  has_many :indirect_assessments
-  has_many :surveys
-  has_many :participations
-  has_many :other_assessments
+
+  has_many :outcome_assessments
+  has_many :direct_assessments, through: :outcome_assessments, source: :assessment, source_type: "DirectAssessment"
+  has_many :indirect_assessments, through: :outcome_assessments, source: :assessment, source_type: "IndirectAssessment"
+
   has_many :alignments
   accepts_nested_attributes_for :alignments,
     reject_if: ->(attributes) { attributes[:level].blank? }

--- a/app/models/outcome_assessment.rb
+++ b/app/models/outcome_assessment.rb
@@ -1,0 +1,4 @@
+class OutcomeAssessment < ActiveRecord::Base
+  belongs_to :assessment, polymorphic: true
+  belongs_to :outcome
+end

--- a/app/views/direct_assessments/edit.html.erb
+++ b/app/views/direct_assessments/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="five columns centered">
-    <h4>Edit a <i>new direct assessment</i> for outcome "<%= @assessment.outcome.name %>. <%= @assessment.outcome.description %>"</h4>
+    <h4>Edit direct assessment <%= @assessment.name %>. <%= @assessment.description %>"</h4>
   </div>
 </div>
 

--- a/app/views/indirect_assessments/edit.html.erb
+++ b/app/views/indirect_assessments/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="five columns centered">
-    <h4>Edit results for outcome "<%= @assessment.outcome.name %>. <%= @assessment.outcome.description %>"</h4>
+    <h4>Edit assessment "<%= @assessment.name %>. <%= @assessment.description %>"</h4>
   </div>
 </div>
 

--- a/db/migrate/20150615152639_create_outcome_assessments.rb
+++ b/db/migrate/20150615152639_create_outcome_assessments.rb
@@ -1,0 +1,9 @@
+class CreateOutcomeAssessments < ActiveRecord::Migration
+  def change
+    create_table :outcome_assessments do |t|
+      t.references :outcome, null: false, index: true
+      t.references :assessment, polymorphic: true, null: false, index: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150615160653_remove_outcome_id_from_assessments.rb
+++ b/db/migrate/20150615160653_remove_outcome_id_from_assessments.rb
@@ -1,0 +1,6 @@
+class RemoveOutcomeIdFromAssessments < ActiveRecord::Migration
+  def change
+    remove_column :direct_assessments, :outcome_id, :integer
+    remove_column :indirect_assessments, :outcome_id, :integer
+  end
+end

--- a/db/migrate/20150615190415_add_department_id_to_assessments.rb
+++ b/db/migrate/20150615190415_add_department_id_to_assessments.rb
@@ -1,0 +1,6 @@
+class AddDepartmentIdToAssessments < ActiveRecord::Migration
+  def change
+    add_reference :direct_assessments, :department, null: false, index: true
+    add_reference :indirect_assessments, :department, null: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150615155716) do
+ActiveRecord::Schema.define(version: 20150615190415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,12 +56,13 @@ ActiveRecord::Schema.define(version: 20150615155716) do
     t.string   "problem_description"
     t.string   "minimum_requirement"
     t.integer  "target_percentage"
-    t.integer  "outcome_id"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
     t.integer  "subject_id",          null: false
+    t.integer  "department_id",       null: false
   end
 
+  add_index "direct_assessments", ["department_id"], name: "index_direct_assessments_on_department_id", using: :btree
   add_index "direct_assessments", ["subject_id"], name: "index_direct_assessments_on_subject_id", using: :btree
 
   create_table "indirect_assessments", force: :cascade do |t|
@@ -70,11 +71,24 @@ ActiveRecord::Schema.define(version: 20150615155716) do
     t.string   "survey_question"
     t.string   "minimum_requirement"
     t.integer  "target_percentage"
-    t.integer  "outcome_id"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
     t.string   "type",                null: false
+    t.integer  "department_id",       null: false
   end
+
+  add_index "indirect_assessments", ["department_id"], name: "index_indirect_assessments_on_department_id", using: :btree
+
+  create_table "outcome_assessments", force: :cascade do |t|
+    t.integer  "outcome_id",      null: false
+    t.integer  "assessment_id",   null: false
+    t.string   "assessment_type", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "outcome_assessments", ["assessment_type", "assessment_id"], name: "index_outcome_assessments_on_assessment_type_and_assessment_id", using: :btree
+  add_index "outcome_assessments", ["outcome_id"], name: "index_outcome_assessments_on_outcome_id", using: :btree
 
   create_table "outcomes", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,14 +39,16 @@ FactoryGirl.define do
   end
 
   factory :direct_assessment do
+    department
     description "Integration"
     minimum_requirement "7 points out of 10"
     name "Problem Set 1"
-    outcome
     problem_description "Question 3, Integration by parts"
     target_percentage 80
 
     after(:build) do |assessment|
+      course = build(:course, department: assessment.department)
+      assessment.outcomes << build(:outcome, course: course)
       unless assessment.subject.present?
         assessment.subject = build(
           :subject,
@@ -57,11 +59,16 @@ FactoryGirl.define do
   end
 
   factory :other_assessment do
+    department
     description "Senior Thesis Completion"
     name "Percent of students who complete a senior thesis"
-    outcome
     target_percentage 80
     type "OtherAssessment"
+
+    after(:build) do |assessment|
+      course = build(:course, department: assessment.department)
+      assessment.outcomes << build(:outcome, course: course)
+    end
   end
 
   factory :outcome do
@@ -77,11 +84,16 @@ FactoryGirl.define do
   end
 
   factory :participation do
+    department
     description "Undergraduation Research Project"
     name "UROP"
-    outcome
     target_percentage 80
     type "Participation"
+
+    after(:build) do |assessment|
+      course = build(:course, department: assessment.department)
+      assessment.outcomes << build(:outcome, course: course)
+    end
   end
 
   factory :standard_outcome do
@@ -96,13 +108,18 @@ FactoryGirl.define do
   end
 
   factory :survey do
+    department
     description "Biennial survey administered to graduating seniors"
     minimum_requirement "Somewhat satisfied"
     name "Senior Survey"
-    outcome
     survey_question "How satisfied are you with advising in your major?"
     target_percentage 80
     type "Survey"
+
+    after(:build) do |assessment|
+      course = build(:course, department: assessment.department)
+      assessment.outcomes << build(:outcome, course: course)
+    end
   end
 
   factory :user do

--- a/spec/features/user_creates_a_result_spec.rb
+++ b/spec/features/user_creates_a_result_spec.rb
@@ -44,7 +44,7 @@ feature "User creates a result" do
     assessment = create(:direct_assessment)
     user = user_with_admin_access_to(assessment.department)
 
-    visit outcome_path(assessment.outcome, as: user)
+    visit outcome_path(assessment.outcomes.first, as: user)
 
     within("#direct_assessment-#{assessment.id}") do
       click_on "View and add results"
@@ -61,7 +61,7 @@ feature "User creates a result" do
     assessment = create(:survey)
     user = user_with_admin_access_to(assessment.department)
 
-    visit outcome_path(assessment.outcome, as: user)
+    visit outcome_path(assessment.outcomes.first, as: user)
 
     within("#indirect_assessment-#{assessment.id}") do
       click_on "View and add results"
@@ -90,7 +90,7 @@ feature "User creates a result" do
     assessment = create(:participation)
     user = user_with_admin_access_to(assessment.department)
 
-    visit outcome_path(assessment.outcome, as: user)
+    visit outcome_path(assessment.outcomes.first, as: user)
 
     within("#indirect_assessment-#{assessment.id}") do
       click_on "View and add results"

--- a/spec/features/user_updates_direct_assessment_spec.rb
+++ b/spec/features/user_updates_direct_assessment_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "User updates a direct assessment" do
   scenario "a direct assessment is successfully updated" do
     assessment = create(:direct_assessment, target_percentage: 50)
-    outcome = assessment.outcome
+    outcome = assessment.outcomes.first
     user = user_with_admin_access_to(outcome.course.department)
 
     visit outcome_path(outcome, as: user)

--- a/spec/features/user_updates_other_assessment_spec.rb
+++ b/spec/features/user_updates_other_assessment_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "User updates other assessment" do
   scenario "other assessment is successfully updated" do
     assessment = create(:other_assessment, name: "Senior Thesis")
-    outcome = assessment.outcome
+    outcome = assessment.outcomes.first
     user = user_with_admin_access_to(outcome.course.department)
 
     visit outcome_path(outcome, as: user)

--- a/spec/features/user_updates_participation_spec.rb
+++ b/spec/features/user_updates_participation_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "User updates a participation assessment" do
   scenario "a participation assessment is successfully updated" do
     assessment = create(:participation, name: "UROP")
-    outcome = assessment.outcome
+    outcome = assessment.outcomes.first
     user = user_with_admin_access_to(outcome.course.department)
 
     visit outcome_path(outcome, as: user)

--- a/spec/features/user_updates_survey_spec.rb
+++ b/spec/features/user_updates_survey_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "User updates a survey assessment" do
   scenario "a survey assessment is successfully updated" do
     assessment = create(:survey, name: "Senior Survey")
-    outcome = assessment.outcome
+    outcome = assessment.outcomes.first
     user = user_with_admin_access_to(outcome.course.department)
 
     visit outcome_path(outcome, as: user)

--- a/spec/features/user_visits_outcome_spec.rb
+++ b/spec/features/user_visits_outcome_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 feature "User visits outcome" do
   scenario "and sees existing assessments" do
     outcome = create(:outcome)
-    direct_assessment = create(:direct_assessment, outcome: outcome)
-    indirect_assessment = create(:survey, outcome: outcome)
+    direct_assessment = create(:direct_assessment)
+    direct_assessment.outcomes << outcome
+    indirect_assessment = create(:survey)
+    indirect_assessment.outcomes << outcome
     user = user_with_admin_access_to(outcome.course.department)
 
     visit course_path(outcome.course, as: user)


### PR DESCRIPTION
If multiple courses within a given department have identical outcomes and those outcomes have the same assessments, we should not duplicate the assessments since the results only need to be entered once.

* Remove outcome_id from direct and indirect assessments and introduce outcome_assessments polymorphic join table
* Add department_id to direct and indirect assessments since `department` can no longer be delegated to an outcome
* Fix specs and factories to work with new schema