### PR TITLE
Consistently refer to Standard Outcomes

### DIFF
--- a/app/controllers/outcomes_controller.rb
+++ b/app/controllers/outcomes_controller.rb
@@ -18,8 +18,8 @@ class OutcomesController < ApplicationController
   def new
     @outcome = course.outcomes.build
 
-    StandardOutcome.all.each do |default_outcome|
-      @outcome.alignments.build(standard_outcome: default_outcome)
+    StandardOutcome.all.each do |standard_outcome|
+      @outcome.alignments.build(standard_outcome: standard_outcome)
     end
 
     authorize(@outcome)

--- a/app/controllers/standard_outcomes_controller.rb
+++ b/app/controllers/standard_outcomes_controller.rb
@@ -1,4 +1,4 @@
-class DefaultOutcomesController < ApplicationController
+class StandardOutcomesController < ApplicationController
   def create
     course = Course.find(params[:course_id])
     authorize(course, :create_outcomes?)

--- a/app/views/courses/_interstitial.html.erb
+++ b/app/views/courses/_interstitial.html.erb
@@ -4,8 +4,8 @@
   </div>
 
   <div class="row">
-    <%=link_to "Adopt Default Outcomes",
-      course_default_outcomes_path(course) %>
+    <%=link_to "Adopt Standard Outcomes",
+      course_standard_outcomes_path(course) %>
   </div>
 
   <div class="row">

--- a/app/views/outcomes/_unaligned_standard_outcomes.html.erb
+++ b/app/views/outcomes/_unaligned_standard_outcomes.html.erb
@@ -15,7 +15,7 @@
           <td><%= standard_outcome %>
           <td>
             <%= button_to t(".adopt"),
-              course_default_outcomes_path(course, ids: standard_outcome.id) %>
+              course_standard_outcomes_path(course, ids: standard_outcome.id) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/outcomes_dashboard/_without_outcomes_actions.html.erb
+++ b/app/views/outcomes_dashboard/_without_outcomes_actions.html.erb
@@ -1,2 +1,2 @@
-<%= link_to t(".adopt_default"), course_default_outcomes_path(course) %>
+<%= link_to t(".adopt_standard"), course_standard_outcomes_path(course) %>
 <%= link_to t(".create_custom"), new_course_outcome_path(course) %>

--- a/app/views/standard_outcomes/index.html.erb
+++ b/app/views/standard_outcomes/index.html.erb
@@ -16,4 +16,4 @@
 </table>
 
 <%= button_to t(".adopt_all", course: @course),
-  course_default_outcomes_path(@course, ids: @outcomes.pluck(:id)) %>
+  course_standard_outcomes_path(@course, ids: @outcomes.pluck(:id)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
       description: Description
       heading: Outcomes for %{name}
       label: Label
-  default_outcomes:
+  standard_outcomes:
     create:
       error: Course already has associated outcomes.
       success:
@@ -25,7 +25,7 @@ en:
     index:
       adopt_all: Adopt All Custom Outcomes For %{course}
       description: Description
-      heading: Default Outcomes
+      heading: Standard Outcomes
   departments:
     show:
       course_name: Course Name
@@ -90,7 +90,7 @@ en:
     unaligned_outcomes_actions:
       edit_outcomes: Edit Outcomes
     without_outcomes_actions:
-      adopt_default: Adopt Default Outcomes
+      adopt_standard: Adopt Standard Outcomes
       create_custom: Create Custom Outcome
   results:
     create: Result created successfully.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   end
 
   resources :courses, only: [:show] do
-    resources :default_outcomes, only: [:index, :create]
+    resources :standard_outcomes, only: [:index, :create]
     resources :outcomes, only: [:new, :create, :index]
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -98,7 +98,7 @@ FactoryGirl.define do
 
   factory :standard_outcome do
     name { generate(:label) }
-    description { "description for default #{name}" }
+    description { "description for standard #{name}" }
   end
 
   factory :subject do

--- a/spec/features/admin_adopts_standard_outcomes_for_course_spec.rb
+++ b/spec/features/admin_adopts_standard_outcomes_for_course_spec.rb
@@ -7,7 +7,7 @@ feature "Admin adopts standard outcomes for a course" do
     user = user_with_admin_access_to(course.department)
 
     visit outcomes_dashboard_path(course, as: user)
-    click_on "Adopt Default Outcomes"
+    click_on "Adopt Standard Outcomes"
 
     expect(page).to have_content(standard_outcomes.first)
     expect(page).to have_content(standard_outcomes.last)

--- a/spec/features/admin_views_outcomes_dashboard_spec.rb
+++ b/spec/features/admin_views_outcomes_dashboard_spec.rb
@@ -9,7 +9,7 @@ feature "Admin views outcomes dashboard" do
 
     expect(page).to have_content "do not have any associated outcomes"
     expect(page).to have_content course.name
-    expect(page).to have_link "Adopt Default Outcomes"
+    expect(page).to have_link "Adopt Standard Outcomes"
   end
 
   scenario "sees list of courses with unaligned outcomes" do

--- a/spec/views/courses/_interstitial.html.erb_spec.rb
+++ b/spec/views/courses/_interstitial.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe "courses/_interstitial.html.erb" do
 
     render "courses/interstitial", course: course
 
-    expect(page).to have_link "Adopt Default Outcomes"
+    expect(page).to have_link "Adopt Standard Outcomes"
   end
 
   it "does not show outcome creation links if unauthorized" do
@@ -16,6 +16,6 @@ describe "courses/_interstitial.html.erb" do
 
     render "courses/interstitial", course: course
 
-    expect(page).not_to have_link "Adopt Default Outcomes"
+    expect(page).not_to have_link "Adopt Standard Outcomes"
   end
 end


### PR DESCRIPTION
We were inconsistently referring to "Default Outcomes" and "Standard
Outcomes" throughout the app. "Standard Outcomes" seems more appropriate,
so this change standardizes (hah!) on that.