### PR TITLE
Allow editing of outcomes

### DIFF
--- a/app/assets/javascripts/outcome_form.js
+++ b/app/assets/javascripts/outcome_form.js
@@ -1,0 +1,22 @@
+$(function(){
+  var alignmentContainer = $("fieldset.alignments");
+
+  var alignmentSorter = function(a, b) {
+    var aName = a.getAttribute("data-order");
+    var bName = b.getAttribute("data-order");
+
+    if (aName > bName) {
+      return 1;
+    } else if (aName < bName) {
+      return -1;
+    } else {
+      return 0;
+    }
+  };
+
+  if (alignmentContainer.length) {
+    var alignments = alignmentContainer.children("fieldset.alignment");
+    alignments.sort(alignmentSorter);
+    alignments.detach().appendTo(alignmentContainer);
+  }
+});

--- a/app/assets/stylesheets/_outcome.scss
+++ b/app/assets/stylesheets/_outcome.scss
@@ -1,19 +1,12 @@
-fieldset.alignments {
-  .input.select {
-    @include row();
+fieldset.alignment {
+  @include row();
 
-    &:not(:last-child) {
-      border-bottom: 1px solid $light-gray;
-      margin-bottom: $base-spacing;
-    }
+  label.outcome {
+   @include span_columns(10);
+  }
 
-    label {
-      @include span_columns(10);
-    }
-
-    select {
-      @include span_columns(2);
-      @include omega();
-    }
+  .controls {
+    @include span_columns(2);
+    @include omega();
   }
 }

--- a/app/controllers/outcomes_controller.rb
+++ b/app/controllers/outcomes_controller.rb
@@ -17,21 +17,36 @@ class OutcomesController < ApplicationController
 
   def new
     @outcome = course.outcomes.build
-
-    StandardOutcome.all.each do |standard_outcome|
-      @outcome.alignments.build(standard_outcome: standard_outcome)
-    end
-
     authorize(@outcome)
+    prepare_alignments(@outcome)
   end
 
   def create
     @outcome = course.outcomes.build(outcome_params)
+    authorize(@outcome)
 
-    if create_outcome(@outcome)
+    if persist_outcome(@outcome)
       redirect_to course_outcomes_path(course), success: t(".success")
     else
       render :new
+    end
+  end
+
+  def edit
+    @outcome = Outcome.includes(:standard_outcomes).find(params[:id])
+    authorize(@outcome)
+    prepare_alignments(@outcome)
+  end
+
+  def update
+    @outcome = Outcome.find(params[:id])
+    @outcome.assign_attributes(outcome_params)
+    authorize(@outcome)
+
+    if persist_outcome(@outcome)
+      redirect_to course_outcomes_path(@outcome.course), success: t(".success")
+    else
+      render :edit
     end
   end
 
@@ -41,7 +56,15 @@ class OutcomesController < ApplicationController
     @course ||= Course.find(params[:course_id])
   end
 
-  def create_outcome(outcome)
+  def prepare_alignments(outcome)
+    StandardOutcome.all.each do |standard_outcome|
+      unless outcome.standard_outcome_ids.include?(standard_outcome.id)
+        @outcome.alignments.build(standard_outcome: standard_outcome)
+      end
+    end
+  end
+
+  def persist_outcome(outcome)
     ActiveRecord::Base.transaction do
       authorize(outcome)
       outcome.course.adopt_custom_outcomes!
@@ -55,6 +78,8 @@ class OutcomesController < ApplicationController
       :description,
       :standard_outcome_id,
       alignments_attributes: [
+        :_destroy,
+        :id,
         :standard_outcome_id,
         :level
       ]

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -4,10 +4,12 @@ class Outcome < ActiveRecord::Base
   has_many :outcome_assessments
   has_many :direct_assessments, through: :outcome_assessments, source: :assessment, source_type: "DirectAssessment"
   has_many :indirect_assessments, through: :outcome_assessments, source: :assessment, source_type: "IndirectAssessment"
-
   has_many :alignments
+  has_many :standard_outcomes, through: :alignments
+
   accepts_nested_attributes_for :alignments,
-    reject_if: ->(attributes) { attributes[:level].blank? }
+    reject_if: ->(attributes) { attributes[:level].blank? },
+    allow_destroy: true
 
   delegate :department, to: :course
 

--- a/app/policies/outcome_policy.rb
+++ b/app/policies/outcome_policy.rb
@@ -7,6 +7,10 @@ class OutcomePolicy < ApplicationPolicy
     user.admin?(record.department)
   end
 
+  def update?
+    user.admin?(record.department)
+  end
+
   def create_assessments?
     create?
   end

--- a/app/views/outcomes/_alignment_fields.html.erb
+++ b/app/views/outcomes/_alignment_fields.html.erb
@@ -1,0 +1,14 @@
+<fieldset class="alignment" data-order="<%= f.object.standard_outcome.name %>">
+  <%= f.input :standard_outcome_id, as: :hidden %>
+  <%= f.label :level, f.object.standard_outcome.to_s, class: "outcome" %>
+
+  <div class = "controls">
+    <%= f.input :level,
+      label: false,
+      prompt: :translate,
+      collection: Alignment::LEVELS %>
+    <% if f.object.persisted? %>
+      <%= f.input :_destroy, as: :boolean %>
+    <% end %>
+  </div>
+</fieldset>

--- a/app/views/outcomes/_form.html.erb
+++ b/app/views/outcomes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [outcome.course, outcome] do |f| %>
+<%= simple_form_for [course, outcome] do |f| %>
   <%= f.input :name %>
   <%= f.input :description %>
 
@@ -6,11 +6,7 @@
     <legend><%= t(".alignments_legend") %></legend>
 
     <%= f.simple_fields_for(:alignments) do |alignment_form| %>
-      <%= alignment_form.input :standard_outcome_id, as: :hidden %>
-      <%= alignment_form.input :level,
-        label: alignment_form.object.standard_outcome,
-        prompt: :translate,
-        collection: Alignment::LEVELS %>
+      <%= render "alignment_fields", f: alignment_form %>
     <% end %>
   </fieldset>
 

--- a/app/views/outcomes/_outcomes.html.erb
+++ b/app/views/outcomes/_outcomes.html.erb
@@ -9,7 +9,7 @@
     <% course.outcomes.each do |outcome| %>
       <tr>
         <td><%= outcome %></td>
-        <td></td>
+        <td><%= link_to t(".edit_outcome"), edit_outcome_path(outcome) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/outcomes/edit.html.erb
+++ b/app/views/outcomes/edit.html.erb
@@ -1,0 +1,4 @@
+<% tab(TabHelper::OUTCOMES) %>
+
+<h1><%= t(".heading") %></h1>
+<%= render "form", course: nil, outcome: @outcome %>

--- a/app/views/outcomes/new.html.erb
+++ b/app/views/outcomes/new.html.erb
@@ -1,4 +1,4 @@
 <% tab(TabHelper::OUTCOMES) %>
 
 <h1><%= t(".heading") %></h1>
-<%= render "form", outcome: @outcome %>
+<%= render "form", course: @outcome.course, outcome: @outcome %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  activerecord:
+    attributes:
+      alignment:
+        _destroy: Remove
   application:
     navigation:
       about: About
@@ -16,16 +20,6 @@ en:
       description: Description
       heading: Outcomes for %{name}
       label: Label
-  standard_outcomes:
-    create:
-      error: Course already has associated outcomes.
-      success:
-        one: Standard outcome successfully adopted.
-        other: Standard outcomes successfully adopted.
-    index:
-      adopt_all: Adopt All Custom Outcomes For %{course}
-      description: Description
-      heading: Standard Outcomes
   departments:
     show:
       course_name: Course Name
@@ -46,6 +40,8 @@ en:
   outcomes:
     create:
       success: Outcome created successfully.
+    edit:
+      heading: Edit Outcome
     form:
       alignments_legend: Alignment Levels
     index:
@@ -58,6 +54,7 @@ en:
     outcomes:
       actions: Actions
       add_outcome: Add A Custom Outcome
+      edit_outcome: Edit Outcome
       outcome: Outcome
     unaligned_standard_outcomes:
       actions: Actions
@@ -66,6 +63,8 @@ en:
         standard outcomes.
       heading: Unaligned Standard Outcomes
       standard_outcome: Standard Outcome
+    update:
+      success: Outcome updated successfully.
   outcomes_dashboard:
     aligned_outcomes_actions:
       edit_assessments: Edit Assessments
@@ -94,5 +93,15 @@ en:
       create_custom: Create Custom Outcome
   results:
     create: Result created successfully.
+  standard_outcomes:
+    create:
+      error: Course already has associated outcomes.
+      success:
+        one: Standard outcome successfully adopted.
+        other: Standard outcomes successfully adopted.
+    index:
+      adopt_all: Adopt All Custom Outcomes For %{course}
+      description: Description
+      heading: Standard Outcomes
   titles:
     application: ABET Outcomes Assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     only: [:show, :edit, :update],
     concerns: :assessments
 
-  resources :outcomes, only: [:show] do
+  resources :outcomes, only: [:show, :edit, :update] do
     resources :assessments, only: [:new]
     resources :direct_assessments, only: [:new, :create]
     resources :indirect_assessments, only: [:new, :create]

--- a/spec/features/admin_edits_outcome_spec.rb
+++ b/spec/features/admin_edits_outcome_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+feature "Admin edits outcome" do
+  scenario "adds additional alignment" do
+    outcome = create(:alignment).outcome
+    standard_outcome = create(:standard_outcome)
+    user = user_with_admin_access_to(outcome.department)
+
+    visit edit_outcome_path(outcome, as: user)
+    select Alignment::MODERATE, from: standard_outcome
+    click_button "Update Outcome"
+
+    expect(page).to have_content "Outcome updated successfully"
+    expect(page).not_to have_css ".unaligned-outcomes"
+  end
+
+  scenario "removes an alignment" do
+    alignment = create(:alignment)
+    user = user_with_admin_access_to(alignment.outcome.department)
+
+    visit edit_outcome_path(alignment.outcome, as: user)
+    check "Remove"
+    click_button "Update Outcome"
+
+    expect(page).to have_css ".unaligned-outcomes"
+  end
+end


### PR DESCRIPTION
Outcomes and their alignments can now be edited. The desire to have all
standard outcomes listed on the outcome form leads to some interesting
controller code to ensure that each standard outcome is represented in
the alignments collection, at least in-memory.

We also wanted the alignments to be sorted, but I could not convince
Rails and `fields_for` to order the in memory collection appropriately
according to the `name` field, regardless of whether the object is
persisted or not. Ultimately, I used jQuery to handle the re-order of
the alignment fields. This works imperceptibly in my experience so I
think it's okay.