### PR TITLE
Conditional subjects index description text

### DIFF
--- a/app/policies/generic_policy.rb
+++ b/app/policies/generic_policy.rb
@@ -1,0 +1,23 @@
+class GenericPolicy
+  attr_reader :user
+
+  def initialize(user, _record)
+    @user = user
+  end
+
+  def create_assessments?
+    user.admin?(AnyDepartment.new)
+  end
+
+  class AnyDepartment
+    def slug
+      self
+    end
+
+    def ==(_other)
+      true
+    end
+  end
+
+  private_constant :AnyDepartment
+end

--- a/app/views/subjects/index.html.erb
+++ b/app/views/subjects/index.html.erb
@@ -1,11 +1,16 @@
-<h1>Subjects</h1>
+<% tab(TabHelper::DATA_ENTRY) %>
+
+<h1><%= t(".heading") %></h1>
+
+<% if policy(:generic).create_assessments? %>
+  <p><%= t(".description.can_create_assessments_html",
+    add_assessment_link: link_to(t(".add_assessment"), "#")) %></p>
+<% else %>
+  <p><%= t(".description.cannot_create_assessments_html") %></p>
+<% end %>
+
 <ul>
   <% @subjects.each do |subject| %>
     <li><%= link_to subject, subject_path(subject) %></li>
   <% end %>
 </ul>
-<p>[IF ACCESS TO CREATE ASSESSMENTS]: If you do not see your subject listed,
-  then you need to [LINK] add an assessment for that subject. </p>
-<p>[IF NO ACCESS TO CREATE ASSESSMENTS]: If you do not see your subject listed,
-then you will need to ask your departmental ABET Administrator to create an
-assessment for your subject.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,5 +103,19 @@ en:
       adopt_all: Adopt All Standard Outcomes For %{course}
       description: Description
       heading: Standard Outcomes
+  subjects:
+    index:
+      add_assessment: add an assessment
+      description:
+        can_create_assessments_html: |
+          You have access to record assessment data for the following subjects.
+          If you do not see your subject listed then you need to
+          %{add_assessment_link} for that subject.
+        cannot_create_assessments_html: |
+          You have access to record assessment data for the following subjects.
+          If you do not see your subject listed then you will need to ask your
+          departmental ABET administrator to create an assessment for your
+          subject.
+      heading: Record Assessment Data For Your Subjects
   titles:
     application: ABET Outcomes Assessment

--- a/spec/policies/generic_policy_spec.rb
+++ b/spec/policies/generic_policy_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe GenericPolicy do
+  include PermissionsHelpers
+
+  describe "#create_assessments" do
+    it "is true if the user is an admin for any department" do
+      department = instance_double(Department, slug: "Foo")
+      user = user_with_admin_access_to(department)
+
+      policy = GenericPolicy.new(user, nil)
+
+      expect(policy.create_assessments?).to eq true
+    end
+
+    it "is false otherwise" do
+      department = instance_double(Department, slug: "Foo")
+      user = user_with_read_access_to(department)
+
+      policy = GenericPolicy.new(user, nil)
+
+      expect(policy.create_assessments?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
We want to show the user different text depending on their ability to
create assessments for any department. This posed an interesting
challenge because our previous permissions checking always dealt with
whether or not the user could perform an action on a specific
department. We will need more of this type of check for other UI
changes.

Our existing code for, for instance, checking if a user is an admin of a
given department iterates over all permissions looking for one where
both the department matches and the access level is admin. In this use
case, we only care about the access level, so we pass in an object that
will *always* pass the department part of that check. This is
`AnyDepartment`.

`AnyDepartment` is explicitly marked as a private constant because I do
not want it leaking out into other parts of the app. The idea is to keep
this concept entirely contained in the policy itself.