### PR TITLE
Separate direct and indirect assessment Pundit policies

### DIFF
--- a/app/controllers/concerns/assessment_authorization.rb
+++ b/app/controllers/concerns/assessment_authorization.rb
@@ -1,9 +1,0 @@
-module AssessmentAuthorization
-  extend ActiveSupport::Concern
-
-  def authorize(assessment)
-    query = action_name + "?"
-    @_pundit_policy_authorized = true
-    AssessmentPolicy.new(current_user, assessment).public_send(query)
-  end
-end

--- a/app/controllers/direct_assessments_controller.rb
+++ b/app/controllers/direct_assessments_controller.rb
@@ -1,6 +1,4 @@
 class DirectAssessmentsController < ApplicationController
-  include AssessmentAuthorization
-
   def new
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = @outcome.direct_assessments.build

--- a/app/controllers/indirect_assessments_controller.rb
+++ b/app/controllers/indirect_assessments_controller.rb
@@ -1,6 +1,4 @@
 class IndirectAssessmentsController < ApplicationController
-  include AssessmentAuthorization
-
   def new
     @outcome = Outcome.find(params[:outcome_id])
     @assessment = @outcome.indirect_assessments.build(type: params[:type])

--- a/app/policies/direct_assessment_policy.rb
+++ b/app/policies/direct_assessment_policy.rb
@@ -1,0 +1,17 @@
+class DirectAssessmentPolicy < ApplicationPolicy
+  def new?
+    GenericPolicy.new(user, record).create_assessments?
+  end
+
+  def create?
+    user.admin?(record.department)
+  end
+
+  def update?
+    create?
+  end
+
+  def show?
+    user.read?(record.department)
+  end
+end

--- a/app/policies/indirect_assessment_policy.rb
+++ b/app/policies/indirect_assessment_policy.rb
@@ -1,4 +1,4 @@
-class AssessmentPolicy < ApplicationPolicy
+class IndirectAssessmentPolicy < ApplicationPolicy
   def create?
     user.admin?(record.department)
   end


### PR DESCRIPTION
Since direct assessments no longer belong to one outcome, we cannot base
authorization on the associated outcome's department. This change bases
authorization for creating new direct assessments on the user's
permission level and not their departments.