### PR TITLE
Enable creation of direct assessment starting with subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,3 @@ tmp
 /config/certs/outcomes-key.pem
 /config/certs/outcomes.cer
 /config/certs/outcomes.jks
-
-
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,4 +319,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.10.3
+   1.10.4

--- a/app/controllers/indirect_assessments_controller.rb
+++ b/app/controllers/indirect_assessments_controller.rb
@@ -7,7 +7,7 @@ class IndirectAssessmentsController < ApplicationController
 
   def create
     @outcome = Outcome.find(params[:outcome_id])
-    @assessment = @outcome.indirect_assessments.build(assessment_params.merge(department_id: @outcome.department.id))
+    @assessment = @outcome.indirect_assessments.build(assessment_params)
     authorize(@outcome)
 
     if @outcome.save

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -2,15 +2,35 @@ class DirectAssessment < ActiveRecord::Base
   has_many :outcome_assessments, as: :assessment
   has_many :outcomes, through: :outcome_assessments
 
-  belongs_to :department
   belongs_to :subject
   has_many :results, as: :assessment
 
   validates :subject, presence: true
+  validate :ensure_single_department
+
+  def department
+    outcomes.first.department
+  end
 
   has_paper_trail
 
   def to_s
     "#{name} - #{description}"
+  end
+
+  private
+
+  def department_ids
+    Outcome.
+      where(id: outcome_ids).
+      joins(course: :department).
+      uniq.
+      pluck("departments.id")
+  end
+
+  def ensure_single_department
+    unless department_ids.length == 1
+      errors.add(:base, :single_department)
+    end
   end
 end

--- a/app/models/indirect_assessment.rb
+++ b/app/models/indirect_assessment.rb
@@ -4,7 +4,9 @@ class IndirectAssessment < ActiveRecord::Base
 
   has_many :results, as: :assessment
 
-  belongs_to :department
+  def department
+    outcomes.first.department
+  end
 
   has_paper_trail
 

--- a/app/policies/direct_assessment_policy.rb
+++ b/app/policies/direct_assessment_policy.rb
@@ -1,10 +1,6 @@
 class DirectAssessmentPolicy < ApplicationPolicy
-  def new?
-    GenericPolicy.new(user, record).create_assessments?
-  end
-
   def create?
-    user.manage_assessments?(record.department)
+    GenericPolicy.new(user, record).create_assessments?
   end
 
   def update?

--- a/app/views/assessments/new.html.erb
+++ b/app/views/assessments/new.html.erb
@@ -2,8 +2,7 @@
 
 Choose type of assessment:<br>
 <ul>
-<li><%=link_to "Grade from an assignment, quiz, or exam", new_outcome_direct_assessment_path(@outcome)%></li>
-<li><%=link_to "Survey results", new_outcome_indirect_assessment_path(@outcome, type: "Survey")%></li>
-<li><%=link_to "Participation in program", new_outcome_indirect_assessment_path(@outcome, type: "Participation")%></li>
-<li><%=link_to "Other", new_outcome_indirect_assessment_path(@outcome, type: "OtherAssessment")%></li>
+  <li><%=link_to "Survey results", new_outcome_indirect_assessment_path(@outcome, type: "Survey")%></li>
+  <li><%=link_to "Participation in program", new_outcome_indirect_assessment_path(@outcome, type: "Participation")%></li>
+  <li><%=link_to "Other", new_outcome_indirect_assessment_path(@outcome, type: "OtherAssessment")%></li>
 </ul>

--- a/app/views/assessments_dashboard/show.html.erb
+++ b/app/views/assessments_dashboard/show.html.erb
@@ -4,7 +4,7 @@
     <h6><%= t(".by") %></h6>
     <h1><%= t(".subject") %></h1>
     <%= link_to t(".get_started"),
-      assessments_courses_path,
+      new_direct_assessment_path,
       class: "button",
       data: { role: "start-direct-assessment" }
     %>

--- a/app/views/direct_assessments/_form.html.erb
+++ b/app/views/direct_assessments/_form.html.erb
@@ -1,58 +1,25 @@
-<%= form_for [@outcome, @assessment] do |f| %>
-  <div class="row">
-    <div class="small-10 large-12">
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label :subject_id, class: "left inline" %>
-        </div>
-        <div class="small-2 columns end">
-          <%= f.select :subject_id,
-            options_from_collection_for_select(Subject.sorted_by_number, :id, :to_s), prompt: "Select a subject" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label "Assignment Name", class: "left inline"%>
-        </div>
-        <div class="small-6 columns end">
-          <%=f.text_field :name, :placeholder => "e.g. Problem Set 1" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label "Assignment Description", class: "left inline"%>
-        </div>
-        <div class="small-6 columns end">
-          <%=f.text_field :description, :placeholder => "e.g. 'Integration'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label "Problem description", class: "left inline"%>
-        </div>
-        <div class="small-6 columns end">
-          <%=f.text_field :problem_description, :placeholder => "e.g. 'Question 3, Integration by parts'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label "Minimum Satisfactory Grade", class: "left inline"%>
-        </div>
-        <div class="small-4 columns end">
-          <%=f.text_field :minimum_requirement, :placeholder => "e.g. '7 points out of 10'" %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="small-2 columns">
-          <%= f.label "Target Percentage", class: "left inline"%>
-        </div>
-        <div class="small-4 columns end">
-          <%=f.text_field	:target_percentage, :placeholder => "Whole number, e.g. '80' for '80%'" %>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <%= button_tag "Submit"%>
+<%= simple_form_for @assessment do |f| %>
+  <%= f.input :subject_id, collection: Subject.sorted_by_number, label_method: :to_s, prompt: "Select a subject" %>
+
+  <br>
+
+  <h4>Outcomes</h4>
+  <% @courses.each do |course| %>
+    <fieldset>
+      <%= course %>
+      <%= f.input :outcome_ids, collection: course.outcomes, label: false, label_method: :to_s, as: :check_boxes %>
+    </fieldset>
+  <% end %>
+
+  <br>
+
+  <%= f.input :name, label: "Assignment name", placeholder: "e.g. Problem Set 1" %>
+  <%= f.input :description, label: "Assignment description", placeholder: "e.g. 'Integration'" %>
+  <%= f.input :problem_description, placeholder: "e.g. 'Question 3, Integration by parts'" %>
+  <%= f.input :minimum_requirement, label: "Minimum grade", placeholder: "e.g. '7 points out of 10'" %>
+  <%= f.input :target_percentage, placeholder: "Whole number, e.g. '80' for '80%'" %>
+  <div class="actions">
+    <%= f.submit "Submit" %>
+    <%= cancel_button %>
   </div>
 <% end %>

--- a/app/views/direct_assessments/edit.html.erb
+++ b/app/views/direct_assessments/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="five columns centered">
-    <h4>Edit direct assessment <%= @assessment.name %>. <%= @assessment.description %>"</h4>
+    <h1>Edit direct assessment <%= @assessment.name %>. <%= @assessment.description %>"</h1>
   </div>
 </div>
 

--- a/app/views/direct_assessments/new.html.erb
+++ b/app/views/direct_assessments/new.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="five columns centered">
-    <h4>Add a <i>new direct assessment</i> for outcome "<%= @outcome.name %>. <%= @outcome.description %>"</h4>
+    <h1>Add a new direct assessment</h1>
   </div>
 </div>
 

--- a/app/views/direct_assessments/show.html.erb
+++ b/app/views/direct_assessments/show.html.erb
@@ -2,34 +2,50 @@
 
 <h1><%= @assessment %></h1>
 <h2><%= @assessment.subject %></h2>
+<ul>
+  <li>Problem description: <%= @assessment.problem_description %></li>
+  <li>Minimum grade: <%= @assessment.minimum_requirement %></li>
+  <li>Target percentage: <%= @assessment.target_percentage %></li>
+</ul>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t(".name") %></th>
-      <th><%= t(".description") %></th>
-      <th><%= t(".problem_description") %></th>
-      <th><%= t(".year") %></th>
-      <th><%= t(".semester") %></th>
-      <th><%= t(".percentage") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @assessment.results.each do |result| %>
+<% if @assessment.results.present? %>
+  <table>
+    <thead>
       <tr>
-        <td><%= result.assessment_name %></td>
-        <td><%= result.assessment_description %></td>
-        <td><%= result.problem_description %></td>
-        <td><%= result.year %></td>
-        <td><%= result.semester %></td>
-        <td><%= result.percentage %></td>
+        <th><%= t(".name") %></th>
+        <th><%= t(".description") %></th>
+        <th><%= t(".problem_description") %></th>
+        <th><%= t(".year") %></th>
+        <th><%= t(".semester") %></th>
+        <th><%= t(".percentage") %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @assessment.results.each do |result| %>
+        <tr>
+          <td><%= result.assessment_name %></td>
+          <td><%= result.assessment_description %></td>
+          <td><%= result.problem_description %></td>
+          <td><%= result.year %></td>
+          <td><%= result.semester %></td>
+          <td><%= result.percentage %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
 
 <% if policy(@assessment).create_results? %>
   <%= link_to t(".add_result"),
     new_direct_assessment_result_path(@assessment),
     class: "button" %>
 <% end %>
+
+<br>
+
+<h2>Outcomes</h2>
+<ul>
+  <% @assessment.outcomes.each do |outcome| %>
+    <li><%= outcome.course %> - <%= link_to outcome, outcome_path(outcome) %></li>
+  <% end %>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,12 @@ en:
               taken: results have already been recorded for this period
             percentage:
               inclusion: must be between 0 and 100
+        direct_assessment:
+          attributes:
+            base:
+              single_department: |
+                Outcomes are required and must be associated with courses in the
+                same department.
   application:
     navigation:
       about: About
@@ -66,6 +72,9 @@ en:
       success: Assessment updated successfully.
   helpers:
     cancel_button: Cancel
+  home:
+    index:
+      heading: Choose a Department
   indirect_assessments:
     create:
       success: Assessment created successfully.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   end
 
   resources :direct_assessments,
-    only: [:show, :edit, :update],
+    only: [:show, :new, :create, :edit, :update],
     concerns: :assessments
 
   resources :indirect_assessments,
@@ -24,7 +24,6 @@ Rails.application.routes.draw do
 
   resources :outcomes, only: [:show, :edit, :update] do
     resources :assessments, only: [:new]
-    resources :direct_assessments, only: [:new, :create]
     resources :indirect_assessments, only: [:new, :create]
   end
 

--- a/db/migrate/20150618135029_remove_department_from_assessments.rb
+++ b/db/migrate/20150618135029_remove_department_from_assessments.rb
@@ -1,0 +1,6 @@
+class RemoveDepartmentFromAssessments < ActiveRecord::Migration
+  def change
+    remove_reference :direct_assessments, :department
+    remove_reference :indirect_assessments, :department
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618031252) do
+ActiveRecord::Schema.define(version: 20150618135029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,10 +59,8 @@ ActiveRecord::Schema.define(version: 20150618031252) do
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
     t.integer  "subject_id",          null: false
-    t.integer  "department_id",       null: false
   end
 
-  add_index "direct_assessments", ["department_id"], name: "index_direct_assessments_on_department_id", using: :btree
   add_index "direct_assessments", ["subject_id"], name: "index_direct_assessments_on_subject_id", using: :btree
 
   create_table "indirect_assessments", force: :cascade do |t|
@@ -74,10 +72,7 @@ ActiveRecord::Schema.define(version: 20150618031252) do
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
     t.string   "type",                null: false
-    t.integer  "department_id",       null: false
   end
-
-  add_index "indirect_assessments", ["department_id"], name: "index_indirect_assessments_on_department_id", using: :btree
 
   create_table "outcome_assessments", force: :cascade do |t|
     t.integer  "outcome_id",      null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,7 +39,6 @@ FactoryGirl.define do
   end
 
   factory :direct_assessment do
-    department
     description "Integration"
     minimum_requirement "7 points out of 10"
     name "Problem Set 1"
@@ -47,27 +46,25 @@ FactoryGirl.define do
     target_percentage 80
 
     after(:build) do |assessment|
-      course = build(:course, department: assessment.department)
-      assessment.outcomes << build(:outcome, course: course)
+      course = create(:course)
+      assessment.outcomes << create(:outcome, course: course)
       unless assessment.subject.present?
         assessment.subject = build(
           :subject,
-          department_number: assessment.department.number
+          department_number: course.department.number
         )
       end
     end
   end
 
   factory :other_assessment do
-    department
     description "Senior Thesis Completion"
     name "Percent of students who complete a senior thesis"
     target_percentage 80
     type "OtherAssessment"
 
     after(:build) do |assessment|
-      course = build(:course, department: assessment.department)
-      assessment.outcomes << build(:outcome, course: course)
+      assessment.outcomes << build(:outcome)
     end
   end
 
@@ -84,15 +81,13 @@ FactoryGirl.define do
   end
 
   factory :participation do
-    department
     description "Undergraduation Research Project"
     name "UROP"
     target_percentage 80
     type "Participation"
 
     after(:build) do |assessment|
-      course = build(:course, department: assessment.department)
-      assessment.outcomes << build(:outcome, course: course)
+      assessment.outcomes << build(:outcome)
     end
   end
 
@@ -108,7 +103,6 @@ FactoryGirl.define do
   end
 
   factory :survey do
-    department
     description "Biennial survey administered to graduating seniors"
     minimum_requirement "Somewhat satisfied"
     name "Senior Survey"
@@ -117,8 +111,7 @@ FactoryGirl.define do
     type "Survey"
 
     after(:build) do |assessment|
-      course = build(:course, department: assessment.department)
-      assessment.outcomes << build(:outcome, course: course)
+      assessment.outcomes << build(:outcome)
     end
   end
 

--- a/spec/features/user_creates_direct_assessment_spec.rb
+++ b/spec/features/user_creates_direct_assessment_spec.rb
@@ -1,24 +1,22 @@
 require "rails_helper"
 
-feature "User creates an assessment" do
+feature "User creates a direct assessment" do
   scenario "a new assessment is created" do
-    subject_title = create(:subject).title
-    outcome = create(:outcome)
-    user = user_with_admin_access_to(outcome.department)
+    subject_ = create(:subject)
+    course = create(:course)
+    outcomes = create_pair(:outcome, course: course)
+    user = user_with_admin_access_to(course.department)
 
     visit assessments_dashboard_path(as: user)
     find("[data-role='start-direct-assessment']").click
 
-    within("#outcome_#{outcome.id}") do
-      click_on "Assess"
-    end
-
-    click_on "Grade from an assignment, quiz, or exam"
+    outcomes.each { |outcome| check(outcome.to_s) }
     fill_and_submit_form
 
-    within("#direct_assessments") do
-      expect(page).to have_content(subject_title)
-    end
+    expect(page).to have_content subject_
+    expect(page).to have_content outcomes.first
+    expect(page).to have_content outcomes.last
+    expect(page).to have_content "Integration by parts"
   end
 
   def fill_and_submit_form

--- a/spec/features/user_updates_direct_assessment_spec.rb
+++ b/spec/features/user_updates_direct_assessment_spec.rb
@@ -4,7 +4,8 @@ feature "User updates a direct assessment" do
   scenario "a direct assessment is successfully updated" do
     assessment = create(:direct_assessment, target_percentage: 50)
     outcome = assessment.outcomes.first
-    user = user_with_admin_access_to(outcome.course.department)
+    other_outcome = create(:outcome, course: outcome.course)
+    user = user_with_admin_access_to(outcome.department)
 
     visit outcome_path(outcome, as: user)
 
@@ -12,11 +13,13 @@ feature "User updates a direct assessment" do
       click_on "Edit"
     end
 
+    check(other_outcome.to_s)
     fill_in "direct_assessment_target_percentage", with: 85
     click_on "Submit"
 
-    within("#direct_assessments") do
-      expect(page).to have_content("85")
-    end
+    expect(page).to have_content assessment.subject
+    expect(page).to have_content outcome
+    expect(page).to have_content other_outcome
+    expect(page).to have_content("85")
   end
 end

--- a/spec/models/indirect_assessment_spec.rb
+++ b/spec/models/indirect_assessment_spec.rb
@@ -1,13 +1,9 @@
 require "rails_helper"
 
-describe DirectAssessment do
-  describe "validations" do
-    it { should validate_presence_of(:subject) }
-  end
-
+describe IndirectAssessment do
   describe "#department" do
     it "should return the department of the first associated outcome" do
-      assessment = create(:direct_assessment)
+      assessment = create(:survey)
       outcome = assessment.outcomes.first
 
       expect(assessment.department).to eq outcome.department

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,4 +10,5 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+  config.example_status_persistence_file_path = "tmp/spec_examples.txt"
 end


### PR DESCRIPTION
https://trello.com/c/ymayP0kT

Instead of having a user choose if they want to create an assessment "by
course" or "by subject", we now take users through two different
workflows when adding direct and indirect assessments.

Indirect assessment creation is similar to the previous workflow; users
choose a course and an outcome and add an assessment.

When users create new direct assessments, they are prompted first to
choose a subject from a dropdown, then are shown all outcomes for the
departments they have access to with check boxes, so they can pick the
ones they want to associate with the new assessment. We used a form
object with an `outcomes_ids` attribute to handle the creation of those
associations.

Since direct assessments have a `department_id` column and we don't know
the department until the assessment is created, we validate that the
outcomes chosen belong to the same department, and set the department of
the new assessment to that department.