### PR TITLE
Add cancel buttons to forms

### DIFF
--- a/app/assets/javascripts/cancel_buttons.js
+++ b/app/assets/javascripts/cancel_buttons.js
@@ -1,6 +1,3 @@
 $(function() {
-  $(".button-cancel").on("click", function(ev) {
-    ev.preventDefault();
-    history.back();
-  });
+  $("a[data-role='cancel-button'").show();
 });

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,9 @@
+module FormHelper
+  def cancel_button
+    link_to t("helpers.cancel_button"),
+      "javascript:history.back()",
+      class: "button button-cancel",
+      style: "display: none",
+      data: { role: "cancel-button" }
+  end
+end

--- a/app/views/outcomes/_form.html.erb
+++ b/app/views/outcomes/_form.html.erb
@@ -14,8 +14,6 @@
 
   <div class="actions">
     <%= f.submit %>
-    <%= link_to t(".cancel"),
-      outcomes_dashboard_path,
-      class: "button button-cancel" %>
+    <%= cancel_button %>
   </div>
 <% end %>

--- a/app/views/results/_form.html.erb
+++ b/app/views/results/_form.html.erb
@@ -17,5 +17,5 @@
 
 <div class="actions">
   <%= f.submit %>
-  <%= link_to t(".cancel"), subjects_path, class: "button button-cancel" %>
+  <%= cancel_button %>
 </div>

--- a/app/views/standard_outcomes/index.html.erb
+++ b/app/views/standard_outcomes/index.html.erb
@@ -19,7 +19,5 @@
   <%= button_to t(".adopt_all", course: @course),
     course_standard_outcomes_path(@course, ids: @outcomes.pluck(:id)) %>
 
-  <%= link_to t(".cancel"),
-    outcomes_dashboard_path,
-    class: "button button-cancel" %>
+  <%= cancel_button %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,18 +51,13 @@ en:
       description: Description
       heading: Outcomes for %{name}
       label: Label
-  departments:
-    show:
-      course_name: Course Name
-      course_number: Course Number
   direct_assessments:
     create:
       success: Assessment created successfully.
     update:
       success: Assessment updated successfully.
-  home:
-    index:
-      heading: Choose a Department
+  helpers:
+    cancel_button: Cancel
   indirect_assessments:
     create:
       success: Assessment created successfully.
@@ -128,7 +123,6 @@ en:
       success: Result created successfully.
     form:
       assessment_background: Background
-      cancel: Cancel
       period: Period
     new:
       heading: Add A New Result


### PR DESCRIPTION
The cancel buttons have a relatively sane default `href` but are
progressively enhanced with JavaScript to be equivalent to pressing the
back button in your browser, which is more likely to be accurate in all
cases.