### PR TITLE
Add validations to outcomes form

### DIFF
--- a/app/assets/stylesheets/_errors.scss
+++ b/app/assets/stylesheets/_errors.scss
@@ -1,0 +1,19 @@
+ul.errors {
+  @extend %default-ul;
+  @include flash($error-color);
+
+  li {
+    text-align: left;
+    margin-left: 2em;
+  }
+}
+
+.field_with_errors input {
+  $error-border-color: darken($error-color, 60%);
+  border-color: $error-border-color;
+
+  &:hover,
+  &:focus, {
+    border-color: $error-border-color;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 
 @import "course";
 @import "direct_assessment";
+@import "errors";
 @import "outcome";
 @import "outcomes";
 @import "outcomes_dashboard";
@@ -22,14 +23,4 @@
 
 .main {
   @include outer-container;
-}
-
-ul.errors {
-  @extend %default-ul;
-  @include flash($error-color);
-
-  li {
-    text-align: left;
-    margin-left: 2em;
-  }
 }

--- a/app/controllers/outcomes_controller.rb
+++ b/app/controllers/outcomes_controller.rb
@@ -28,6 +28,7 @@ class OutcomesController < ApplicationController
     if persist_outcome(@outcome)
       redirect_to course_outcomes_path(course), success: t(".success")
     else
+      prepare_alignments(@outcome)
       render :new
     end
   end
@@ -46,6 +47,7 @@ class OutcomesController < ApplicationController
     if persist_outcome(@outcome)
       redirect_to course_outcomes_path(@outcome.course), success: t(".success")
     else
+      prepare_alignments(@outcome)
       render :edit
     end
   end
@@ -65,10 +67,12 @@ class OutcomesController < ApplicationController
   end
 
   def persist_outcome(outcome)
-    ActiveRecord::Base.transaction do
-      authorize(outcome)
-      outcome.course.adopt_custom_outcomes!
-      outcome.save!
+    if outcome.valid?
+      ActiveRecord::Base.transaction do
+        authorize(outcome)
+        outcome.course.adopt_custom_outcomes!
+        outcome.save!
+      end
     end
   end
 

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,9 @@
+module ErrorsHelper
+  def render_errors(form)
+    errors = form.object.errors
+
+    if errors.any?
+      render "errors", errors: errors.full_messages
+    end
+  end
+end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -11,6 +11,9 @@ class Outcome < ActiveRecord::Base
     reject_if: ->(attributes) { attributes[:level].blank? },
     allow_destroy: true
 
+  validates :name, presence: true, uniqueness: { scope: :course_id }
+  validates :description, presence: true
+
   delegate :department, to: :course
 
   def to_s

--- a/app/views/application/_errors.html.erb
+++ b/app/views/application/_errors.html.erb
@@ -1,0 +1,5 @@
+<ul class="errors">
+  <% errors.each do |error| %>
+    <li><%= error %></li>
+  <% end %>
+</ul>

--- a/app/views/outcomes/_form.html.erb
+++ b/app/views/outcomes/_form.html.erb
@@ -1,4 +1,6 @@
 <%= simple_form_for [course, outcome] do |f| %>
+  <%= render_errors(f) %>
+
   <%= f.input :name %>
   <%= f.input :description %>
 

--- a/app/views/results/_form.html.erb
+++ b/app/views/results/_form.html.erb
@@ -1,10 +1,4 @@
-<% if f.object.errors.any? %>
-  <ul class="errors">
-    <% f.object.errors.full_messages.each do |error| %>
-      <li><%= error %></li>
-    <% end %>
-  </ul>
-<% end %>
+<%= render_errors(f) %>
 
 <fieldset class="period">
   <legend><%= t(".period") %></legend>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -42,7 +42,7 @@ SimpleForm.setup do |config|
     ## Inputs
     b.use :label_input
     b.use :hint,  wrap_with: { tag: :span, class: :hint }
-    b.use :error, wrap_with: { tag: :span, class: :error }
+    # b.use :error, wrap_with: { tag: :span, class: :error }
 
     ## full_messages_for
     # If you want to display the full error message for the attribute, you can

--- a/db/migrate/20150618022614_add_outcomes_constraints.rb
+++ b/db/migrate/20150618022614_add_outcomes_constraints.rb
@@ -1,0 +1,9 @@
+class AddOutcomesConstraints < ActiveRecord::Migration
+  def change
+    change_column_null :outcomes, :name, false
+    change_column_null :outcomes, :description, false
+    change_column_null :outcomes, :course_id, false
+
+    add_index :outcomes, [:course_id, :name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150615190415) do
+ActiveRecord::Schema.define(version: 20150618022614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,12 +91,14 @@ ActiveRecord::Schema.define(version: 20150615190415) do
   add_index "outcome_assessments", ["outcome_id"], name: "index_outcome_assessments_on_outcome_id", using: :btree
 
   create_table "outcomes", force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
-    t.integer  "course_id"
+    t.string   "name",        null: false
+    t.string   "description", null: false
+    t.integer  "course_id",   null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
+
+  add_index "outcomes", ["course_id", "name"], name: "index_outcomes_on_course_id_and_name", unique: true, using: :btree
 
   create_table "results", force: :cascade do |t|
     t.integer  "assessment_id",          null: false


### PR DESCRIPTION
This adds missing database constraints and indexes on outcomes and then
backs them up with validations in the form. This leads to a better user
experience - they have a visual indication of required fields and get
nice errors rather than server errors when things fail.

As part of this change, I configured simple_form to not display error
text for each individual field, instead opting for a summary at the top
of the form. This isn't ideal; Inline error messages would be best with
the summary being reserved for things that relate to more than one
field. However, this was simpler to style in a reasonable manner for
now.