### PR TITLE
Fix form actions styling

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -77,7 +77,7 @@ select {
   width: auto;
 }
 
-.actions {
+.form-actions {
   form {
     display: inline-block;
   }

--- a/app/views/direct_assessments/_form.html.erb
+++ b/app/views/direct_assessments/_form.html.erb
@@ -18,7 +18,7 @@
   <%= f.input :problem_description, placeholder: "e.g. 'Question 3, Integration by parts'" %>
   <%= f.input :minimum_requirement, label: "Minimum grade", placeholder: "e.g. '7 points out of 10'" %>
   <%= f.input :target_percentage, placeholder: "Whole number, e.g. '80' for '80%'" %>
-  <div class="actions">
+  <div class="form-actions">
     <%= f.submit "Submit" %>
     <%= cancel_button %>
   </div>

--- a/app/views/outcomes/_form.html.erb
+++ b/app/views/outcomes/_form.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   </fieldset>
 
-  <div class="actions">
+  <div class="form-actions">
     <%= f.submit %>
     <%= cancel_button %>
   </div>

--- a/app/views/results/_form.html.erb
+++ b/app/views/results/_form.html.erb
@@ -15,7 +15,7 @@
 
 <%= f.input :percentage %>
 
-<div class="actions">
+<div class="form-actions">
   <%= f.submit %>
   <%= cancel_button %>
 </div>

--- a/app/views/standard_outcomes/index.html.erb
+++ b/app/views/standard_outcomes/index.html.erb
@@ -15,7 +15,7 @@
   </tbody>
 </table>
 
-<div class="actions">
+<div class="form-actions">
   <%= button_to t(".adopt_all", course: @course),
     course_standard_outcomes_path(@course, ids: @outcomes.pluck(:id)) %>
 


### PR DESCRIPTION
Using the `.actions` class for the form buttons container was
overlapping in some places with out use of the `.actions` class on table
contents.

Resolved quickly by using `.form-actions` for the form buttons.