### PR TITLE
Add edit outcomes link to fully aligned courses

### DIFF
--- a/app/views/outcomes_dashboard/_aligned_outcomes_actions.html.erb
+++ b/app/views/outcomes_dashboard/_aligned_outcomes_actions.html.erb
@@ -1,1 +1,2 @@
+<%= link_to t(".edit_outcomes"), course_outcomes_path(course) %>
 <%= link_to t(".edit_assessments"), "#" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,18 +10,18 @@ en:
         percentage: Actual Percentage
     errors:
       models:
-        result:
-          attributes:
-            assessment_id:
-              taken: results have already been recorded for this period
-            percentage:
-              inclusion: must be between 0 and 100
         direct_assessment:
           attributes:
             base:
               single_department: |
                 Outcomes are required and must be associated with courses in the
                 same department.
+        result:
+          attributes:
+            assessment_id:
+              taken: results have already been recorded for this period
+            percentage:
+              inclusion: must be between 0 and 100
   application:
     navigation:
       about: About
@@ -112,6 +112,7 @@ en:
   outcomes_dashboard:
     aligned_outcomes_actions:
       edit_assessments: Edit Assessments
+      edit_outcomes: Edit Outcomes
     courses_table:
       actions: Actions
       name: Name


### PR DESCRIPTION
The users still may need to edit or review the outcomes