### PR TITLE
Display list of assessments by course

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -1,4 +1,9 @@
 class AssessmentsController < ApplicationController
+  def index
+    @course = Course.find(params[:course_id])
+    @outcomes = policy_scope(@course.outcomes)
+  end
+
   def new
     @outcome = Outcome.find_by_id(params[:outcome_id])
     authorize(@outcome, :create_assessments?)

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -12,11 +12,11 @@ class DirectAssessment < ActiveRecord::Base
   validates :subject, presence: true
   validate :ensure_single_department
 
+  has_paper_trail
+
   def department
     outcomes.first.department
   end
-
-  has_paper_trail
 
   def to_s
     "#{name} - #{description}"

--- a/app/views/assessments/_direct_assessments.html.erb
+++ b/app/views/assessments/_direct_assessments.html.erb
@@ -1,0 +1,23 @@
+<h4>Direct Assessments</h4>
+<table id="direct_assessments">
+  <tr>
+    <th><%= t(".subject") %></th>
+    <th><%= t(".name") %></th>
+    <th><%= t(".description") %></th>
+    <th><%= t(".minimum") %></th>
+    <th><%= t(".target") %></th>
+    <th></th>
+    <th></th>
+  </tr>
+  <% outcome.direct_assessments.each do |assessment| %>
+    <%= content_tag_for :tr, assessment do %>
+      <td><%= assessment.subject %></td>
+      <td><%= assessment.name %></td>
+      <td><%= assessment.description %></td>
+      <td><%= assessment.minimum_requirement %></td>
+      <td><%= assessment.target_percentage %></td>
+      <td><%= link_to "Edit", edit_direct_assessment_path(assessment) %>
+      <td><%= link_to "View and add results", direct_assessment_path(assessment) %>
+    <% end %>
+  <% end %>
+</table>

--- a/app/views/assessments/_indirect_assessments.html.erb
+++ b/app/views/assessments/_indirect_assessments.html.erb
@@ -1,0 +1,23 @@
+<h4>Indirect Assessments</h4>
+<table id="indirect_assessments">
+  <tr>
+    <th><%= t(".name") %></th>
+    <th><%= t(".description") %></th>
+    <th><%= t(".minimum") %></th>
+    <th><%= t(".target") %></th>
+    <th><%= t(".type") %></th>
+    <th></th>
+    <th></th>
+  </tr>
+  <% outcome.indirect_assessments.each do |assessment| %>
+    <%= content_tag_for :tr, assessment do %>
+      <td><%= assessment.name %></td>
+      <td><%= assessment.description %></td>
+      <td><%= assessment.minimum_requirement %></td>
+      <td><%= assessment.target_percentage %></td>
+      <td><%= assessment_type(assessment) %></td>
+      <td><%= link_to "Edit", edit_indirect_assessment_path(assessment) %></td>
+      <td><%= link_to "View and add results", indirect_assessment_path(assessment) %></td>
+    <% end %>
+  <% end %>
+</table>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -1,0 +1,20 @@
+<% tab(TabHelper::ASSESSMENTS) %>
+
+<h1><%= t(".heading", name: @course) %></h1>
+<%= link_to t(".add_assessment"), assessments_dashboard_path, class: "button" %>
+<br>
+
+<% @outcomes.each do |outcome| %>
+  <% if outcome.direct_assessments.any? || outcome.indirect_assessments.any? %>
+    <h2>Outcome <%= outcome %></h2>
+    <% if outcome.direct_assessments.any? %>
+      <%= render "direct_assessments", outcome: outcome %>
+    <% end %>
+
+    <br>
+
+    <% if outcome.indirect_assessments.any? %>
+      <%= render "indirect_assessments", outcome: outcome %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/outcomes_dashboard/_aligned_outcomes_actions.html.erb
+++ b/app/views/outcomes_dashboard/_aligned_outcomes_actions.html.erb
@@ -1,2 +1,2 @@
 <%= link_to t(".edit_outcomes"), course_outcomes_path(course) %>
-<%= link_to t(".edit_assessments"), assessments_dashboard_path %>
+<%= link_to t(".edit_assessments"), course_assessments_path(course) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,21 @@ en:
         details: Details
         heading: Outcomes for %{name}
         label: Label
+    direct_assessments:
+      description: Assignment Description
+      minimum: Minimum Grade
+      name: Assignment Name
+      subject: Subject
+      target: Target Percentage
+    index:
+      add_assessment: Add new assessment
+      heading: Assessments for %{name}
+    indirect_assessments:
+      description: Description
+      minimum: Minimum Category
+      name: Name
+      target: Target Percentage
+      type: Type
     new:
       heading: Choose an Indirect Assessment Type
       other_assessment: Other Assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :courses, only: [] do
     resources :standard_outcomes, only: [:index, :create]
     resources :outcomes, only: [:new, :create, :index]
+    resources :assessments, only: [:index]
   end
 
   resources :direct_assessments,

--- a/spec/features/user_updates_direct_assessment_spec.rb
+++ b/spec/features/user_updates_direct_assessment_spec.rb
@@ -2,14 +2,19 @@ require "rails_helper"
 
 feature "User updates a direct assessment" do
   scenario "a direct assessment is successfully updated" do
+    course = create(:course, :fully_aligned)
+    outcome, other_outcome = create_pair(:outcome, course: course)
     assessment = create(:direct_assessment, target_percentage: 50)
-    outcome = assessment.outcomes.first
-    other_outcome = create(:outcome, course: outcome.course)
-    user = user_with_admin_access_to(outcome.department)
+    assessment.outcomes << outcome
+    user = user_with_admin_access_to(course.department)
 
-    visit outcome_path(outcome, as: user)
+    visit outcomes_dashboard_path(as: user)
 
-    within("#direct_assessment-#{assessment.id}") do
+    within("table.fully-aligned") do
+      click_on "Edit Assessments"
+    end
+
+    within("#direct_assessment_#{assessment.id}") do
       click_on "Edit"
     end
 

--- a/spec/features/user_updates_other_assessment_spec.rb
+++ b/spec/features/user_updates_other_assessment_spec.rb
@@ -2,13 +2,19 @@ require "rails_helper"
 
 feature "User updates other assessment" do
   scenario "other assessment is successfully updated" do
+    course = create(:course, :fully_aligned)
+    outcome = create(:outcome, course: course)
     assessment = create(:other_assessment, name: "Senior Thesis")
-    outcome = assessment.outcomes.first
-    user = user_with_admin_access_to(outcome.course.department)
+    assessment.outcomes << outcome
+    user = user_with_admin_access_to(course.department)
 
-    visit outcome_path(outcome, as: user)
+    visit outcomes_dashboard_path(as: user)
 
-    within("#indirect_assessment-#{assessment.id}") do
+    within("table.fully-aligned") do
+      click_on "Edit Assessments"
+    end
+
+    within("#indirect_assessment_#{assessment.id}") do
       click_on "Edit"
     end
 

--- a/spec/features/user_updates_participation_spec.rb
+++ b/spec/features/user_updates_participation_spec.rb
@@ -2,13 +2,19 @@ require "rails_helper"
 
 feature "User updates a participation assessment" do
   scenario "a participation assessment is successfully updated" do
+    course = create(:course, :fully_aligned)
+    outcome = create(:outcome, course: course)
     assessment = create(:participation, name: "UROP")
-    outcome = assessment.outcomes.first
-    user = user_with_admin_access_to(outcome.course.department)
+    assessment.outcomes << outcome
+    user = user_with_admin_access_to(course.department)
 
-    visit outcome_path(outcome, as: user)
+    visit outcomes_dashboard_path(as: user)
 
-    within("#indirect_assessment-#{assessment.id}") do
+    within("table.fully-aligned") do
+      click_on "Edit Assessments"
+    end
+
+    within("#indirect_assessment_#{assessment.id}") do
       click_on "Edit"
     end
 

--- a/spec/features/user_updates_survey_spec.rb
+++ b/spec/features/user_updates_survey_spec.rb
@@ -2,13 +2,19 @@ require "rails_helper"
 
 feature "User updates a survey assessment" do
   scenario "a survey assessment is successfully updated" do
+    course = create(:course, :fully_aligned)
+    outcome = create(:outcome, course: course)
     assessment = create(:survey, name: "Senior Survey")
-    outcome = assessment.outcomes.first
-    user = user_with_admin_access_to(outcome.course.department)
+    assessment.outcomes << outcome
+    user = user_with_admin_access_to(course.department)
 
-    visit outcome_path(outcome, as: user)
+    visit outcomes_dashboard_path(as: user)
 
-    within("#indirect_assessment-#{assessment.id}") do
+    within("table.fully-aligned") do
+      click_on "Edit Assessments"
+    end
+
+    within("#indirect_assessment_#{assessment.id}") do
       click_on "Edit"
     end
 


### PR DESCRIPTION
https://trello.com/c/y65cLV2q

From the "Manage Outcomes" page, have the "Edit Assessments" link point
to an assessments index page which displays all assessments associated
with a course by outcome. From here, users will be able to update
assessments and the outcomes they are associated with.