### PR TITLE
Improve check box list display creating assessment

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -154,3 +154,13 @@ select {
 .simple-form-chunk {
   margin-bottom: $large-spacing;
 }
+
+.checkbox label {
+  display: inline-block;
+  max-width: 95%;
+}
+
+.checkbox input {
+  margin-top: $small-spacing/2;
+  vertical-align: top;
+}

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -58,7 +58,7 @@ SimpleForm.setup do |config|
   # Defaults to :nested for bootstrap config.
   #   inline: input + label
   #   nested: label > input
-  config.boolean_style = :nested
+  config.boolean_style = :inline
 
   # Default class for buttons
   config.button_class = 'btn'
@@ -92,7 +92,7 @@ SimpleForm.setup do |config|
   # You can wrap each item in a collection of radio/check boxes with a tag,
   # defaulting to :span. Please note that when using :boolean_style = :nested,
   # SimpleForm will force this option to be a label.
-  # config.item_wrapper_tag = :span
+  config.item_wrapper_tag = :div
 
   # You can define a class to use in all item wrappers. Defaulting to none.
   # config.item_wrapper_class = nil


### PR DESCRIPTION
Previously, long outcomes would wrap around to have text under the
check box which broke up the list of check boxes down the left rail. With
these changes the check boxes all line up down the left rail and long
labels do not wrap under the check boxes.