### PR TITLE
Display number of assessments for outcomes

### DIFF
--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,5 +1,5 @@
 class DirectAssessment < ActiveRecord::Base
-  has_many :outcome_assessments, as: :assessment
+  has_many :outcome_assessments, as: :assessment, dependent: :destroy
   has_many :outcomes, through: :outcome_assessments
 
   belongs_to :subject

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,7 +1,7 @@
 class Outcome < ActiveRecord::Base
   belongs_to :course, counter_cache: true
 
-  has_many :outcome_assessments
+  has_many :outcome_assessments, dependent: :destroy
   has_many :direct_assessments, through: :outcome_assessments, source: :assessment, source_type: "DirectAssessment"
   has_many :indirect_assessments, through: :outcome_assessments, source: :assessment, source_type: "IndirectAssessment"
   has_many :alignments

--- a/app/models/outcome_assessment.rb
+++ b/app/models/outcome_assessment.rb
@@ -1,4 +1,4 @@
 class OutcomeAssessment < ActiveRecord::Base
   belongs_to :assessment, polymorphic: true
-  belongs_to :outcome
+  belongs_to :outcome, counter_cache: :assessments_count
 end

--- a/app/views/manage_assessments/assessments/index.html.erb
+++ b/app/views/manage_assessments/assessments/index.html.erb
@@ -8,7 +8,7 @@
 
 <% @outcomes.each do |outcome| %>
   <% if outcome.direct_assessments.any? || outcome.indirect_assessments.any? %>
-    <h2>Outcome <%= outcome %></h2>
+    <h2>Outcome <%= outcome %> (<%= t(".assessments_count", count: outcome.assessments_count) %>)</h2>
     <% if outcome.direct_assessments.any? %>
       <%= render "direct_assessments", outcome: outcome %>
     <% end %>

--- a/app/views/manage_outcomes/outcomes/_outcomes.html.erb
+++ b/app/views/manage_outcomes/outcomes/_outcomes.html.erb
@@ -2,6 +2,7 @@
   <thead>
     <tr>
       <th><%= t(".outcome") %></th>
+      <th><%= t(".assessments_count") %></th>
       <th><%= t(".actions") %></th>
     </tr>
   </thead>
@@ -9,6 +10,7 @@
     <% course.outcomes.each do |outcome| %>
       <tr>
         <td><%= outcome %></td>
+        <td><%= outcome.assessments_count %></td>
         <td><%= link_to t(".edit_outcome"), edit_manage_outcomes_outcome_path(outcome) %></td>
       </tr>
     <% end %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -27,6 +27,9 @@ en:
       index:
         add_assessment: Add new assessment
         heading: Assessments for %{name}
+        assessments_count:
+          one: 1 assessment
+          other: "%{count} assessments"
       indirect_assessments:
         description: Description
         edit: Edit

--- a/config/locales/manage_outcomes.en.yml
+++ b/config/locales/manage_outcomes.en.yml
@@ -66,6 +66,7 @@ en:
       outcomes:
         actions: Actions
         add_outcome: Add A Custom Outcome
+        assessments_count: Number of Assessments
         edit_outcome: Edit Outcome
         outcome: Outcome
       unaligned_standard_outcomes:

--- a/db/migrate/20150619205350_add_counter_cache_to_outcomes.rb
+++ b/db/migrate/20150619205350_add_counter_cache_to_outcomes.rb
@@ -1,0 +1,5 @@
+class AddCounterCacheToOutcomes < ActiveRecord::Migration
+  def change
+    add_column :outcomes, :assessments_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618174454) do
+ActiveRecord::Schema.define(version: 20150619205350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,11 +87,12 @@ ActiveRecord::Schema.define(version: 20150618174454) do
   add_index "outcome_assessments", ["outcome_id"], name: "index_outcome_assessments_on_outcome_id", using: :btree
 
   create_table "outcomes", force: :cascade do |t|
-    t.string   "name",        null: false
-    t.string   "description", null: false
-    t.integer  "course_id",   null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.string   "name",                          null: false
+    t.string   "description",                   null: false
+    t.integer  "course_id",                     null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "assessments_count", default: 0, null: false
   end
 
   add_index "outcomes", ["course_id", "name"], name: "index_outcomes_on_course_id_and_name", unique: true, using: :btree

--- a/spec/models/outcome_spec.rb
+++ b/spec/models/outcome_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Outcome do
+  context "counter cache" do
+    it "counts the number of direct and indirect assessments" do
+      outcome = create(:outcome)
+      outcome.direct_assessments << create(:direct_assessment)
+      outcome.indirect_assessments << create(:survey)
+
+      expect(outcome.assessments_count).to eq 2
+    end
+
+    it "decreases when assessments are removed" do
+      outcome = create(:outcome)
+      direct_assessment = create(:direct_assessment)
+      outcome.direct_assessments << direct_assessment
+      direct_assessment.destroy
+
+      expect(outcome.reload.assessments_count).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
Add counter cache of `assessments_count` to outcomes, and add `dependent: :destroy` to the join relationship so that the cache correctly decreases when an assessment is deleted.