### PR TITLE
Proper sorting for outcomes wherever shown

### DIFF
--- a/app/views/manage_assessments/assessments/index.html.erb
+++ b/app/views/manage_assessments/assessments/index.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <br>
 
-<% @outcomes.each do |outcome| %>
+<% @outcomes.order(:name).each do |outcome| %>
   <% if outcome.direct_assessments.any? || outcome.indirect_assessments.any? %>
     <h2>Outcome <%= outcome %> (<%= t(".assessments_count", count: outcome.assessments_count) %>)</h2>
     <% if outcome.direct_assessments.any? %>

--- a/app/views/manage_assessments/courses/index.html.erb
+++ b/app/views/manage_assessments/courses/index.html.erb
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <% course.outcomes.each do |outcome| %>
+        <% course.outcomes.order(:name).each do |outcome| %>
           <%= content_tag_for(:tr, outcome) do %>
             <td><%= outcome.name%></td>
             <td><%= outcome.description%></td>

--- a/app/views/manage_assessments/direct_assessments/_form.html.erb
+++ b/app/views/manage_assessments/direct_assessments/_form.html.erb
@@ -10,7 +10,7 @@
     <legend><%= course %></legend
 
     <%= f.input :outcome_ids,
-      collection: course.outcomes.sorted_by_name,
+      collection: course.outcomes.order(:name),
       label: false,
       label_method: :to_s,
       as: :check_boxes %>

--- a/app/views/manage_assessments/direct_assessments/_form.html.erb
+++ b/app/views/manage_assessments/direct_assessments/_form.html.erb
@@ -10,7 +10,7 @@
     <legend><%= course %></legend
 
     <%= f.input :outcome_ids,
-      collection: course.outcomes,
+      collection: course.outcomes.sorted_by_name,
       label: false,
       label_method: :to_s,
       as: :check_boxes %>

--- a/app/views/manage_outcomes/outcomes/_unaligned_standard_outcomes.html.erb
+++ b/app/views/manage_outcomes/outcomes/_unaligned_standard_outcomes.html.erb
@@ -10,7 +10,7 @@
       </tr>
     </thead>
     <tbody>
-      <% outcomes.each do |standard_outcome| %>
+      <% outcomes.order(:name).each do |standard_outcome| %>
         <tr>
           <td><%= standard_outcome %>
           <td>

--- a/app/views/manage_outcomes/standard_outcomes/index.html.erb
+++ b/app/views/manage_outcomes/standard_outcomes/index.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @outcomes.each do |outcome| %>
+    <% @outcomes.order(:name).each do |outcome| %>
       <tr>
         <td><%= outcome %></td>
       </tr>

--- a/app/views/manage_results/direct_assessments/_outcomes.html.erb
+++ b/app/views/manage_results/direct_assessments/_outcomes.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t(".heading") %></h2>
 <ul>
-  <% outcomes.each do |outcome| %>
+  <% outcomes.order(:name).each do |outcome| %>
     <li>
       <%= link_to_if policy(outcome.course).show?,
         "#{outcome.course} - #{outcome}",

--- a/app/views/manage_results/indirect_assessments/_outcomes.html.erb
+++ b/app/views/manage_results/indirect_assessments/_outcomes.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t(".heading") %></h2>
 <ul>
-  <% outcomes.each do |outcome| %>
+  <% outcomes.order(:name).each do |outcome| %>
     <li>
       <%= link_to_if policy(outcome.course).show?,
         "#{outcome.course} - #{outcome}",


### PR DESCRIPTION
The outcomes were displaying in arbitrary order, sorting them by name instead wherever I could find them. 