### PR TITLE
Improve archiving

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -114,7 +114,8 @@ select {
   @include clearfix;
 
   label,
-  input {
+  input,
+  select {
     @include media($medium-screen-up) {
       @include span-columns(8);
     }

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -21,6 +21,10 @@ th {
 
 td {
   border-bottom: $base-border;
+
+  a {
+    display: block;
+  }
 }
 
 tr,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,4 +24,12 @@ class ApplicationController < ActionController::Base
   def user_not_authorized
     render file: "public/401.html", status: :unauthorized
   end
+
+  def redirect_to_back_or_default(default, *args)
+    if request.env["HTTP_REFERER"].present? && request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
+      redirect_to :back, *args
+    else
+      redirect_to default, *args
+    end
+  end
 end

--- a/app/controllers/manage_assessments/archives_controller.rb
+++ b/app/controllers/manage_assessments/archives_controller.rb
@@ -1,0 +1,10 @@
+module ManageAssessments
+  class ArchivesController < ApplicationController
+    def create
+      assessment = DirectAssessment.find(params[:direct_assessment_id])
+      authorize(assessment, :update?)
+      assessment.update_attributes(archived: true)
+      redirect_to_back_or_default root_path, success: t(".success")
+    end
+  end
+end

--- a/app/controllers/manage_assessments/direct_assessments_controller.rb
+++ b/app/controllers/manage_assessments/direct_assessments_controller.rb
@@ -54,6 +54,7 @@ class ManageAssessments::DirectAssessmentsController < ApplicationController
 
   def direct_assessment_params
     params.require(:direct_assessment).permit(
+      :archived,
       :description,
       :minimum_requirement,
       :name,

--- a/app/controllers/manage_assessments/indirect_assessments_controller.rb
+++ b/app/controllers/manage_assessments/indirect_assessments_controller.rb
@@ -41,6 +41,7 @@ class ManageAssessments::IndirectAssessmentsController < ApplicationController
   def assessment_params
     params.require(:indirect_assessment).permit(
       :actual_percentage,
+      :archived,
       :description,
       :minimum_requirement,
       :name,

--- a/app/controllers/manage_results/direct_assessments_controller.rb
+++ b/app/controllers/manage_results/direct_assessments_controller.rb
@@ -4,11 +4,6 @@ class ManageResults::DirectAssessmentsController < ApplicationController
     authorize(@assessment)
   end
 
-  def edit
-    @assessment = DirectAssessment.find(params[:id])
-    authorize(@assessment)
-  end
-
   def update
     @assessment = DirectAssessment.find(params[:id])
     authorize(@assessment)

--- a/app/controllers/manage_results/direct_assessments_controller.rb
+++ b/app/controllers/manage_results/direct_assessments_controller.rb
@@ -3,13 +3,4 @@ class ManageResults::DirectAssessmentsController < ApplicationController
     @assessment = DirectAssessment.find(params[:id])
     authorize(@assessment)
   end
-
-  def update
-    @assessment = DirectAssessment.find(params[:id])
-    authorize(@assessment)
-    @assessment.archived = 'true'
-    @assessment.save
-    @subject = @assessment.subject
-    redirect_to manage_results_subject_path(@subject)
-  end
 end

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,4 +1,6 @@
 class DirectAssessment < ActiveRecord::Base
+  default_scope { where("archived = false") }
+
   has_many :outcome_assessments, as: :assessment, dependent: :destroy
   has_many :outcomes, through: :outcome_assessments
 

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,6 +1,4 @@
 class DirectAssessment < ActiveRecord::Base
-  default_scope { where("archived = false") }
-
   has_many :outcome_assessments, as: :assessment, dependent: :destroy
   has_many :outcomes, through: :outcome_assessments
 

--- a/app/policies/subject_policy.rb
+++ b/app/policies/subject_policy.rb
@@ -3,6 +3,10 @@ class SubjectPolicy < ApplicationPolicy
     user.read?(record.department)
   end
 
+  def manage_assessments?
+    user.manage_assessments?(record.department)
+  end
+
   class Scope < Scope
     def resolve
       Subject.

--- a/app/views/manage_assessments/direct_assessments/_form.html.erb
+++ b/app/views/manage_assessments/direct_assessments/_form.html.erb
@@ -35,6 +35,10 @@
 <%= f.input :target_percentage,
   placeholder: "Whole number, e.g. '80' for '80%'" %>
 
+<%= f.input :archived,
+  as: :select,
+  include_blank: false %>
+
 <div class="form-actions">
   <%= f.submit "Submit" %>
   <%= cancel_button %>

--- a/app/views/manage_results/subjects/show.html.erb
+++ b/app/views/manage_results/subjects/show.html.erb
@@ -9,7 +9,7 @@
         <th><%= t(".assessment") %></th>
         <th><%= t(".minimum_grade") %></th>
         <th><%= t(".target_percentage") %></th>
-        <th colspan="3"><%= t(".actions") %></th>
+        <th class="actions"><%= t(".actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -22,8 +22,17 @@
             <% if policy(:generic).create_assessments? %>
               <%= link_to t(".edit"), edit_manage_assessments_direct_assessment_path(assessment) %>
             <% end %>
+
+            <% if policy(@subject).manage_assessments? %>
+              <%= link_to t(".archive"),
+                manage_assessments_direct_assessment_archive_path(direct_assessment_id: assessment),
+                method: "post",
+                data: { confirm: t(".archive_confirm") }%>
+            <% end %>
+
+            <%= link_to t(".results"),
+              manage_results_direct_assessment_path(assessment) %>
           </td>
-          <td><%= link_to t(".results"), manage_results_direct_assessment_path(assessment) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/manage_results/subjects/show.html.erb
+++ b/app/views/manage_results/subjects/show.html.erb
@@ -24,10 +24,6 @@
             <% end %>
           </td>
           <td><%= link_to t(".results"), manage_results_direct_assessment_path(assessment) %></td>
-          <td><% if policy(:generic).create_assessments? %>
-              <%= link_to t(".archive"), manage_results_direct_assessment_path(assessment),
-              :method => :put, data: { confirm: t(".confirm") }%>
-              <% end %> </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/other_assessments/_other_assessment_form.html.erb
+++ b/app/views/other_assessments/_other_assessment_form.html.erb
@@ -4,6 +4,7 @@
 <%= f.input :description %>
 <%= f.input :minimum_requirement %>
 <%= f.input :target_percentage %>
+<%= f.input :archived, as: :select, include_blank: false %>
 
 <div class="form-actions">
   <%= f.submit %>

--- a/app/views/participations/_participation_form.html.erb
+++ b/app/views/participations/_participation_form.html.erb
@@ -4,6 +4,7 @@
 <%= f.input :description %>
 <%= f.input :minimum_requirement %>
 <%= f.input :target_percentage %>
+<%= f.input :archived, as: :select, include_blank: false %>
 
 <div class="form-actions">
   <%= f.submit %>

--- a/app/views/surveys/_survey_form.html.erb
+++ b/app/views/surveys/_survey_form.html.erb
@@ -6,6 +6,7 @@
 <%= f.input :survey_question %>
 <%= f.input :minimum_requirement %>
 <%= f.input :target_percentage %>
+<%= f.input :archived, as: :select, include_blank: false %>
 
 <div class="form-actions">
   <%= f.submit %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -1,6 +1,9 @@
 ---
 en:
   manage_assessments:
+    archives:
+      create:
+        success: Assessment has been archived successfully.
     assessments:
       new:
         heading: Choose an Indirect Assessment Type

--- a/config/locales/manage_results.en.yml
+++ b/config/locales/manage_results.en.yml
@@ -63,6 +63,8 @@ en:
         no_assessments: No direct assessments
         edit: Edit
         archive: Archive
-        confirm: Are you sure you want to archive this assessment?
+        archive_confirm: Are you sure you want to archive this assessment? You
+          should archive this assessment only if you no longer wish to collect
+          data for it.
         results: View and Add Results
         target_percentage: Target Percentage

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -9,6 +9,8 @@ en:
       default_message: "Please review the problems below:"
     hints:
       direct_assessment:
+        archived: Set to "Yes" if you no longer need to collect data on this
+          assessment.
         assignment_description: Brief description of the topic of this
           assignment
         assignment_name: For example, "Problem Set 1" or "Quiz 2"
@@ -19,6 +21,9 @@ en:
         target_percentage: The percent of students who should receive a
           satisfactory grade on this problem if, in general, students have
           learned the material. For example, 80 percent.
+      indirect_assessment:
+        archived: Set to "Yes" if you no longer need to collect data on this
+          assessment.
       outcome:
         description: The text of the student learning outcome. The skill or
           ability that the students should have achieved by the time of

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   end
 
   namespace :manage_results do
-    resources :direct_assessments, only: [:show, :update], concerns: :resultable
+    resources :direct_assessments, only: [:show], concerns: :resultable
     resources :indirect_assessments, only: [:show], concerns: :resultable
     resources :results, only: [:edit, :update, :destroy]
     resources :subjects, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
       resources :assessments, only: [:index]
     end
 
-    resources :direct_assessments, only: [:new, :create, :edit, :update]
+    resources :direct_assessments, only: [:new, :create, :edit, :update] do
+      resource :archive, only: [:create]
+    end
+
     resources :indirect_assessments, only: [:edit, :update]
 
     resources :outcomes, only: [] do

--- a/db/migrate/20151202181421_add_archived_to_indirect_assessments.rb
+++ b/db/migrate/20151202181421_add_archived_to_indirect_assessments.rb
@@ -1,0 +1,6 @@
+class AddArchivedToIndirectAssessments < ActiveRecord::Migration
+  def change
+    add_column :indirect_assessments, :archived, :boolean, default: false
+    add_index :indirect_assessments, :archived
+  end
+end

--- a/db/migrate/20151202181542_add_index_to_archived_on_direct_assessments.rb
+++ b/db/migrate/20151202181542_add_index_to_archived_on_direct_assessments.rb
@@ -1,0 +1,5 @@
+class AddIndexToArchivedOnDirectAssessments < ActiveRecord::Migration
+  def change
+    add_index :direct_assessments, :archived
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150917171020) do
+ActiveRecord::Schema.define(version: 20151202181542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,18 +63,22 @@ ActiveRecord::Schema.define(version: 20150917171020) do
     t.boolean  "archived",            default: false
   end
 
+  add_index "direct_assessments", ["archived"], name: "index_direct_assessments_on_archived", using: :btree
   add_index "direct_assessments", ["subject_id"], name: "index_direct_assessments_on_subject_id", using: :btree
 
   create_table "indirect_assessments", force: :cascade do |t|
-    t.string   "name",                null: false
-    t.string   "description",         null: false
+    t.string   "name",                                null: false
+    t.string   "description",                         null: false
     t.string   "survey_question"
-    t.string   "minimum_requirement", null: false
-    t.integer  "target_percentage",   null: false
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.string   "type",                null: false
+    t.string   "minimum_requirement",                 null: false
+    t.integer  "target_percentage",                   null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.string   "type",                                null: false
+    t.boolean  "archived",            default: false
   end
+
+  add_index "indirect_assessments", ["archived"], name: "index_indirect_assessments_on_archived", using: :btree
 
   create_table "outcome_assessments", force: :cascade do |t|
     t.integer  "outcome_id",      null: false

--- a/spec/features/user_archives_assessments_spec.rb
+++ b/spec/features/user_archives_assessments_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+feature "User archives assessments" do
+  scenario "when preparing to enter results for direct assessments" do
+    assessment = create(:direct_assessment)
+    user = user_with_assessments_access_to(assessment.outcomes.first.department)
+
+    visit manage_results_subject_path(assessment.subject, as: user)
+    click_link "Archive"
+
+    expect(page).to have_content "has been archived"
+    expect(page).not_to have_content assessment.name
+  end
+end


### PR DESCRIPTION
* Add ability to archive indirect assessments and direct assessments
  from the assessment edit form.
* Change "archive" link when reporting results to go to a dedicated
  controller for this action.
* Only show edit link if the user is authorized to perform that action
* Clean up the display of links in tables so they don't run together.
* Remove unused controller actions