### PR TITLE
Remove default scope on direct assessments

### DIFF
--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,6 +1,4 @@
 class DirectAssessment < ActiveRecord::Base
-  default_scope { where("archived = false") }
-
   has_many :outcome_assessments, as: :assessment, dependent: :destroy
   has_many :outcomes, through: :outcome_assessments
 
@@ -15,6 +13,10 @@ class DirectAssessment < ActiveRecord::Base
   validate :ensure_single_department
 
   has_paper_trail
+
+  def self.unarchived
+    where(archived: false)
+  end
 
   def department
     if outcomes.length > 0

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,13 +1,12 @@
 class Subject < ActiveRecord::Base
-  has_many :direct_assessments
+  has_many :direct_assessments, -> { merge(DirectAssessment.unarchived) }
 
   def self.sorted_by_number
     order(number: :asc).sort_by { |s| s.number.to_f }
   end
 
   def self.with_direct_assessments
-    includes(:direct_assessments).
-      where.not(direct_assessments: { subject_id: nil })
+    joins(:direct_assessments).uniq
   end
 
   def to_s

--- a/spec/models/direct_assessment_spec.rb
+++ b/spec/models/direct_assessment_spec.rb
@@ -5,6 +5,15 @@ describe DirectAssessment do
     it { should validate_presence_of(:subject) }
   end
 
+  describe ".unarchived" do
+    it "returns only unarchived direct assessments" do
+      assessment = create(:direct_assessment, archived: false)
+      create(:direct_assessment, archived: true)
+
+      expect(DirectAssessment.unarchived).to eq [assessment]
+    end
+  end
+
   describe "#department" do
     it "should return the department of the first associated outcome" do
       assessment = create(:direct_assessment)

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -18,8 +18,9 @@ describe Subject do
   end
 
   describe ".with_direct_assessments" do
-    it "returns subjects with associated direct assessments" do
+    it "returns subjects with associated unarchived direct assessments" do
       subject_ = create(:direct_assessment).subject
+      create(:direct_assessment, archived: true)
       create(:subject)
 
       expect(Subject.with_direct_assessments).to eq [subject_]
@@ -40,6 +41,16 @@ describe Subject do
       the_subject = create(:subject, department_number: department.number)
 
       expect(the_subject.department).to eq department
+    end
+  end
+
+  describe "#direct_assessments" do
+    it "includes only unarchived direct assessments" do
+      subject_ = create(:subject)
+      unarchived_assessment = create(:direct_assessment, subject: subject_)
+      create(:direct_assessment, subject: subject_, archived: true)
+
+      expect(subject_.direct_assessments).to eq [unarchived_assessment]
     end
   end
 end


### PR DESCRIPTION
This proved to be a problem when trying to create a UI for unarchiving
assessments. You can call `unscoped` to remove all previous scopes
(including the default scope) but that means your scopes are more order
dependent than desired.

This change updates subject so it is related only to unarchived direct
assessments. There's no context in the app where we'd care to know about
a subjects archived direct assessments.

This also means we now have an interface for unarchiving assessments
because archived assessments will once again show up on the "manage
assessments" screen for a given course. This is probably not the final
UI here, but this is a step in the correct direction.