### PR TITLE
Clean up N+1 queries in various views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "turbolinks"
 gem "uglifier"
 
 group :development do
+  gem "bullet"
   gem "capistrano-rails"
   gem "capistrano-rvm"
   gem "gssapi", git: "git@github.com:derekprior/gssapi.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,9 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
+    bullet (4.14.10)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -258,6 +261,7 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    uniform_notifier (1.9.0)
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
@@ -274,6 +278,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  bullet
   bundler-audit
   byebug
   capistrano-rails

--- a/app/controllers/manage_assessments/assessments_controller.rb
+++ b/app/controllers/manage_assessments/assessments_controller.rb
@@ -1,7 +1,9 @@
 class ManageAssessments::AssessmentsController < ApplicationController
   def index
     @course = Course.find(params[:course_id])
-    @outcomes = policy_scope(@course.outcomes)
+    @outcomes = policy_scope(@course.outcomes).
+      includes(direct_assessments: :subject).
+      includes(:indirect_assessments)
   end
 
   def new

--- a/app/controllers/manage_assessments/courses_controller.rb
+++ b/app/controllers/manage_assessments/courses_controller.rb
@@ -3,6 +3,6 @@ class ManageAssessments::CoursesController < ApplicationController
   after_action :verify_policy_scoped
 
   def index
-    @courses = policy_scope(Course)
+    @courses = policy_scope(Course).includes(outcomes: :department)
   end
 end

--- a/app/controllers/manage_assessments/direct_assessments_controller.rb
+++ b/app/controllers/manage_assessments/direct_assessments_controller.rb
@@ -23,7 +23,7 @@ class ManageAssessments::DirectAssessmentsController < ApplicationController
 
   def edit
     @assessment = DirectAssessment.find(params[:id])
-    @courses = @assessment.department.courses.with_outcomes
+    @courses = @assessment.department.courses.with_outcomes.includes(:outcomes)
     authorize(@assessment)
   end
 

--- a/app/controllers/manage_outcomes/outcomes_controller.rb
+++ b/app/controllers/manage_outcomes/outcomes_controller.rb
@@ -4,7 +4,9 @@ class ManageOutcomes::OutcomesController < ApplicationController
 
   def index
     @course = course
-    @unaligned_standard_outcomes = StandardOutcome.unaligned_with(course)
+    @unaligned_standard_outcomes = StandardOutcome.
+      unaligned_with(course).
+      order(:name)
     authorize(@course, :show?)
   end
 

--- a/app/controllers/manage_results/direct_assessments_controller.rb
+++ b/app/controllers/manage_results/direct_assessments_controller.rb
@@ -1,6 +1,9 @@
 class ManageResults::DirectAssessmentsController < ApplicationController
   def show
-    @assessment = DirectAssessment.find(params[:id])
+    @assessment = DirectAssessment.
+      includes(results: :assessment).
+      includes(outcomes: :department).
+      find(params[:id])
     authorize(@assessment)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,6 @@
 class Course < ActiveRecord::Base
   belongs_to :department
-  has_many :outcomes
+  has_many :outcomes, -> { order(:name) }
 
   def self.without_outcomes
     where(outcomes_count: 0)

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,6 +1,6 @@
 class DirectAssessment < ActiveRecord::Base
   has_many :outcome_assessments, as: :assessment, dependent: :destroy
-  has_many :outcomes, through: :outcome_assessments
+  has_many :outcomes, -> { order(:name) }, through: :outcome_assessments
 
   belongs_to :subject
   has_many :results, as: :assessment

--- a/app/models/indirect_assessment.rb
+++ b/app/models/indirect_assessment.rb
@@ -1,6 +1,6 @@
 class IndirectAssessment < ActiveRecord::Base
   has_many :outcome_assessments, as: :assessment
-  has_many :outcomes, through: :outcome_assessments
+  has_many :outcomes, -> { order(:name) }, through: :outcome_assessments
   has_many :courses, through: :outcomes
   has_many :results, as: :assessment
 

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -6,6 +6,7 @@ class Outcome < ActiveRecord::Base
   has_many :indirect_assessments, through: :outcome_assessments, source: :assessment, source_type: "IndirectAssessment"
   has_many :alignments
   has_many :standard_outcomes, through: :alignments
+  has_one :department, through: :course
 
   accepts_nested_attributes_for :alignments,
     reject_if: ->(attributes) { attributes[:level].blank? },
@@ -13,8 +14,6 @@ class Outcome < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: { scope: :course_id }
   validates :description, presence: true
-
-  delegate :department, to: :course
 
   has_paper_trail
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,5 +1,7 @@
 class Subject < ActiveRecord::Base
-  has_many :direct_assessments, -> { merge(DirectAssessment.unarchived) }
+  has_many :direct_assessments, -> {
+    merge(DirectAssessment.unarchived).order(:name)
+  }
 
   def self.sorted_by_number
     order(number: :asc).sort_by { |s| s.number.to_f }

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -10,6 +10,7 @@ class CoursePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       Course.
+        order(:id).
         joins(:department).
         where(departments: { slug: user.department_slugs })
     end

--- a/app/policies/direct_assessment_policy.rb
+++ b/app/policies/direct_assessment_policy.rb
@@ -22,6 +22,7 @@ class DirectAssessmentPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       Course.
+        order(:id).
         joins(:department).
         where(
           departments: {

--- a/app/views/manage_assessments/assessments/index.html.erb
+++ b/app/views/manage_assessments/assessments/index.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <br>
 
-<% @outcomes.order(:name).each do |outcome| %>
+<% @outcomes.each do |outcome| %>
   <% if outcome.direct_assessments.any? || outcome.indirect_assessments.any? %>
     <h2>Outcome <%= outcome %> (<%= t(".assessments_count", count: outcome.assessments_count) %>)</h2>
     <% if outcome.direct_assessments.any? %>

--- a/app/views/manage_assessments/courses/index.html.erb
+++ b/app/views/manage_assessments/courses/index.html.erb
@@ -1,7 +1,7 @@
 <% tab(TabHelper::ASSESSMENTS) %>
 
 <% @courses.each do |course| %>
-  <% if course.outcomes.any? %>
+  <% if course.outcomes_count > 0 %>
     <h2><%= course %></h2>
     <table class="outcomes">
       <thead>
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <% course.outcomes.order(:name).each do |outcome| %>
+        <% course.outcomes.each do |outcome| %>
           <%= content_tag_for(:tr, outcome) do %>
             <td><%= outcome.name%></td>
             <td><%= outcome.description%></td>

--- a/app/views/manage_assessments/dashboard/show.html.erb
+++ b/app/views/manage_assessments/dashboard/show.html.erb
@@ -27,7 +27,7 @@
 <h2>Manage Existing Assessments</h2>
 <div>
   <ul>
-    <% @courses.order(:id).each do |course| %>
+    <% @courses.each do |course| %>
       <li><%= link_to course, manage_assessments_course_assessments_path(course) %></li>
     <% end %>
   </ul>

--- a/app/views/manage_assessments/direct_assessments/_form.html.erb
+++ b/app/views/manage_assessments/direct_assessments/_form.html.erb
@@ -5,12 +5,12 @@
 
 <%= f.label :outcome_ids %>
 
-<% courses.order(:id).each do |course| %>
+<% courses.each do |course| %>
   <fieldset class="course-outcomes">
     <legend><%= course %></legend
 
     <%= f.input :outcome_ids,
-      collection: course.outcomes.order(:name),
+      collection: course.outcomes,
       label: false,
       label_method: :to_s,
       as: :check_boxes %>

--- a/app/views/manage_outcomes/outcomes/_outcomes.html.erb
+++ b/app/views/manage_outcomes/outcomes/_outcomes.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% course.outcomes.order(:name).each do |outcome| %>
+    <% course.outcomes.each do |outcome| %>
       <tr>
         <td><%= outcome %></td>
         <td><%= outcome.assessments_count %></td>

--- a/app/views/manage_outcomes/outcomes/_unaligned_standard_outcomes.html.erb
+++ b/app/views/manage_outcomes/outcomes/_unaligned_standard_outcomes.html.erb
@@ -10,7 +10,7 @@
       </tr>
     </thead>
     <tbody>
-      <% outcomes.order(:name).each do |standard_outcome| %>
+      <% outcomes.each do |standard_outcome| %>
         <tr>
           <td><%= standard_outcome %>
           <td>

--- a/app/views/manage_outcomes/standard_outcomes/index.html.erb
+++ b/app/views/manage_outcomes/standard_outcomes/index.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @outcomes.order(:name).each do |outcome| %>
+    <% @outcomes.each do |outcome| %>
       <tr>
         <td><%= outcome %></td>
       </tr>

--- a/app/views/manage_results/subjects/show.html.erb
+++ b/app/views/manage_results/subjects/show.html.erb
@@ -13,7 +13,7 @@
       </tr>
     </thead>
     <tbody>
-      <% @subject.direct_assessments.order([:name]).each do |assessment| %>
+      <% @subject.direct_assessments.each do |assessment| %>
         <tr id="direct_assessment-<%=assessment.id %>">
           <td><%= assessment %></td>
           <td><%= assessment.minimum_requirement %></td>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,4 +10,11 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
   config.action_view.raise_on_missing_translations = true
   config.action_controller.action_on_unpermitted_parameters = :raise
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+    Bullet.console = true
+  end
 end

--- a/spec/services/adoption_spec.rb
+++ b/spec/services/adoption_spec.rb
@@ -11,6 +11,7 @@ describe Adoption do
       level: Alignment::HIGH
     )
 
+    course.reload
     expect(course.outcomes.size).to eq 1
     expect(course.outcomes.first.to_s).to eq standard_outcome.to_s
     expect(alignment).to be_present


### PR DESCRIPTION
* Add `bullet` gem to help detect N+1 query issues.
* Add `includes` in various controllers to eager load associated data
  that we know we're going to need.
* Update associations to provide sane default ordering so we don't need
  to re-order in the view.
* Add a `has_one` association for `department` rather than delegating so
  it can be eager loaded through an association.