### PR TITLE
Update redirects used after managing assessments

### DIFF
--- a/app/controllers/manage_assessments/indirect_assessments_controller.rb
+++ b/app/controllers/manage_assessments/indirect_assessments_controller.rb
@@ -11,8 +11,10 @@ class ManageAssessments::IndirectAssessmentsController < ApplicationController
     authorize(@outcome)
 
     if @outcome.save
-      redirect_to manage_results_indirect_assessment_path(@assessment),
+      redirect_to(
+        manage_assessments_course_assessments_path(@assessment.courses.first),
         success: t(".success")
+      )
     else
       render :new
     end
@@ -29,8 +31,10 @@ class ManageAssessments::IndirectAssessmentsController < ApplicationController
     authorize(@assessment)
 
     if @assessment.save
-      redirect_to manage_results_indirect_assessment_path(@assessment),
+      redirect_to(
+        manage_assessments_course_assessments_path(@assessment.courses.first),
         success: t(".success")
+      )
     else
       render :edit
     end

--- a/app/helpers/flashes_helper.rb
+++ b/app/helpers/flashes_helper.rb
@@ -1,0 +1,5 @@
+module FlashesHelper
+  def user_facing_flashes
+    flash.to_hash.slice("alert", "error", "notice", "success")
+  end
+end

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -1,6 +1,7 @@
 class DirectAssessment < ActiveRecord::Base
   has_many :outcome_assessments, as: :assessment, dependent: :destroy
   has_many :outcomes, -> { order(:name) }, through: :outcome_assessments
+  has_many :courses, -> { order(:id) }, through: :outcomes
 
   belongs_to :subject
   has_many :results, as: :assessment

--- a/app/models/indirect_assessment.rb
+++ b/app/models/indirect_assessment.rb
@@ -1,7 +1,7 @@
 class IndirectAssessment < ActiveRecord::Base
   has_many :outcome_assessments, as: :assessment
   has_many :outcomes, -> { order(:name) }, through: :outcome_assessments
-  has_many :courses, through: :outcomes
+  has_many :courses, -> { order(:id) }, through: :outcomes
   has_many :results, as: :assessment
 
   validates :description, presence: true

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,7 +1,13 @@
-<% if flash.any? %>
+<% if user_facing_flashes.any? %>
   <div class="flashes">
-    <% flash.each do |key, value| -%>
-      <div class="flash-<%= key %>"><%= value %></div>
+    <% user_facing_flashes.each do |key, value| -%>
+      <div class="flash-<%= key %>">
+        <% if flash[:html_safe].present? %>
+          <%= raw value %>
+        <% else %>
+          <%= value %>
+        <% end %>
+      </div>
     <% end -%>
   </div>
 <% end %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -61,7 +61,7 @@ en:
         label: Label
     direct_assessments:
       create:
-        success: Assessment created successfully.
+        success: Assessment created successfully. View assessments for %{links}.
       edit:
         heading: Edit Direct Assessment
       new:

--- a/spec/features/user_creates_direct_assessment_spec.rb
+++ b/spec/features/user_creates_direct_assessment_spec.rb
@@ -12,6 +12,7 @@ feature "User creates a direct assessment" do
 
     outcomes.each { |outcome| check(outcome.to_s) }
     fill_and_submit_form
+    click_link course.name
 
     expect(page).to have_content subject_
     expect(page).to have_content outcomes.first


### PR DESCRIPTION
This previously brought the user to a screen to create or view results
for this assessment. However, it's far more likely that you will want to
stay in the context of managing assessments.

For creating direct assessments, we now redirect back to the form with
the previous subject pre-selected. The flash message has links to return
to the listing of assessments for the courses that were selected in the
previous assessment. This gives users the ability to enter many new
assessments for a subject in a less painful manner.

Other redirects were also updated to bring the user to more logical
assessment locations.