### PR TITLE
Remove CoffeeScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 ruby "2.2.2"
 
 gem "rails", "~> 4.2.0"
-gem "coffee-rails"
 gem "email_validator"
 gem "flutie"
 gem "high_voltage"


### PR DESCRIPTION
We have very little JavaScript as it is, and all of it is plain old
JavaScript so we don't need this.