### PR TITLE
Make `department` a proper association on subject

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,6 @@
 class Subject < ActiveRecord::Base
+  belongs_to :department, foreign_key: :department_number, primary_key: :number
+
   has_many :direct_assessments, -> {
     merge(DirectAssessment.unarchived).order(:name)
   }
@@ -13,9 +15,5 @@ class Subject < ActiveRecord::Base
 
   def to_s
     "#{number} - #{title}"
-  end
-
-  def department
-    Department.find_by(number: department_number)
   end
 end


### PR DESCRIPTION
This allows us to more easily pre-load it and query through it. This may
come in handy on activity feeds and reporting and is a more railsy-way
to specify what we have in the `department` method.