### PR TITLE
Track number of active assessments for an outcome

### DIFF
--- a/app/controllers/manage_assessments/archives_controller.rb
+++ b/app/controllers/manage_assessments/archives_controller.rb
@@ -1,10 +1,21 @@
 module ManageAssessments
   class ArchivesController < ApplicationController
     def create
-      assessment = DirectAssessment.find(params[:direct_assessment_id])
       authorize(assessment, :update?)
-      assessment.update_attributes(archived: true)
+      assessment.archive
       redirect_to_back_or_default root_path, success: t(".success")
+    end
+
+    def destroy
+      authorize(assessment, :update?)
+      assessment.unarchive
+      redirect_to_back_or_default root_path, success: t(".success")
+    end
+
+    private
+
+    def assessment
+      @_assessment ||= DirectAssessment.find(params[:direct_assessment_id])
     end
   end
 end

--- a/app/controllers/manage_assessments/direct_assessments_controller.rb
+++ b/app/controllers/manage_assessments/direct_assessments_controller.rb
@@ -59,7 +59,6 @@ class ManageAssessments::DirectAssessmentsController < ApplicationController
 
   def direct_assessment_params
     params.require(:direct_assessment).permit(
-      :archived,
       :description,
       :minimum_requirement,
       :name,

--- a/app/controllers/manage_assessments/indirect_assessments_controller.rb
+++ b/app/controllers/manage_assessments/indirect_assessments_controller.rb
@@ -45,7 +45,6 @@ class ManageAssessments::IndirectAssessmentsController < ApplicationController
   def assessment_params
     params.require(:indirect_assessment).permit(
       :actual_percentage,
-      :archived,
       :description,
       :minimum_requirement,
       :name,

--- a/app/models/direct_assessment.rb
+++ b/app/models/direct_assessment.rb
@@ -29,6 +29,14 @@ class DirectAssessment < ActiveRecord::Base
     "#{name} - #{description}"
   end
 
+  def archive
+    AssessmentArchivist.archive(self)
+  end
+
+  def unarchive
+    AssessmentArchivist.unarchive(self)
+  end
+
   private
 
   def department_ids

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,12 +1,18 @@
 class Outcome < ActiveRecord::Base
   belongs_to :course, counter_cache: true
 
+  has_one :department, through: :course
   has_many :outcome_assessments, dependent: :destroy
-  has_many :direct_assessments, through: :outcome_assessments, source: :assessment, source_type: "DirectAssessment"
-  has_many :indirect_assessments, through: :outcome_assessments, source: :assessment, source_type: "IndirectAssessment"
   has_many :alignments
   has_many :standard_outcomes, through: :alignments
-  has_one :department, through: :course
+  has_many :direct_assessments,
+    through: :outcome_assessments,
+    source: :assessment,
+    source_type: "DirectAssessment"
+  has_many :indirect_assessments,
+    through: :outcome_assessments,
+    source: :assessment,
+    source_type: "IndirectAssessment"
 
   accepts_nested_attributes_for :alignments,
     reject_if: ->(attributes) { attributes[:level].blank? },

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -26,4 +26,8 @@ class Outcome < ActiveRecord::Base
   def to_s
     "#{name} - #{description}"
   end
+
+  def active_assessments_count
+    assessments_count - archived_assessments_count
+  end
 end

--- a/app/services/assessment_archivist.rb
+++ b/app/services/assessment_archivist.rb
@@ -1,0 +1,35 @@
+class AssessmentArchivist
+  def self.archive(*args)
+    new(*args).archive
+  end
+
+  def self.unarchive(*args)
+    new(*args).unarchive
+  end
+
+  def initialize(assessment)
+    @assessment = assessment
+  end
+
+  def archive
+    ActiveRecord::Base.transaction do
+      assessment.update!(archived: true)
+      assessment.outcomes.update_all <<-SQL
+        archived_assessments_count = archived_assessments_count + 1
+      SQL
+    end
+  end
+
+  def unarchive
+    ActiveRecord::Base.transaction do
+      assessment.update!(archived: false)
+      assessment.outcomes.update_all <<-SQL
+        archived_assessments_count = GREATEST(0, archived_assessments_count - 1)
+      SQL
+    end
+  end
+
+  private
+
+  attr_reader :assessment
+end

--- a/app/views/manage_assessments/direct_assessments/_form.html.erb
+++ b/app/views/manage_assessments/direct_assessments/_form.html.erb
@@ -35,10 +35,6 @@
 <%= f.input :target_percentage,
   placeholder: "Whole number, e.g. '80' for '80%'" %>
 
-<%= f.input :archived,
-  as: :select,
-  include_blank: false %>
-
 <div class="form-actions">
   <%= f.submit "Submit" %>
   <%= cancel_button %>

--- a/app/views/other_assessments/_other_assessment_form.html.erb
+++ b/app/views/other_assessments/_other_assessment_form.html.erb
@@ -4,7 +4,6 @@
 <%= f.input :description %>
 <%= f.input :minimum_requirement %>
 <%= f.input :target_percentage %>
-<%= f.input :archived, as: :select, include_blank: false %>
 
 <div class="form-actions">
   <%= f.submit %>

--- a/app/views/participations/_participation_form.html.erb
+++ b/app/views/participations/_participation_form.html.erb
@@ -4,7 +4,6 @@
 <%= f.input :description %>
 <%= f.input :minimum_requirement %>
 <%= f.input :target_percentage %>
-<%= f.input :archived, as: :select, include_blank: false %>
 
 <div class="form-actions">
   <%= f.submit %>

--- a/app/views/surveys/_survey_form.html.erb
+++ b/app/views/surveys/_survey_form.html.erb
@@ -6,7 +6,6 @@
 <%= f.input :survey_question %>
 <%= f.input :minimum_requirement %>
 <%= f.input :target_percentage %>
-<%= f.input :archived, as: :select, include_blank: false %>
 
 <div class="form-actions">
   <%= f.submit %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -4,6 +4,8 @@ en:
     archives:
       create:
         success: Assessment has been archived successfully.
+      destroy:
+        success: Assessment has been unarchived successfully.
     assessments:
       new:
         heading: Choose an Indirect Assessment Type

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -9,8 +9,6 @@ en:
       default_message: "Please review the problems below:"
     hints:
       direct_assessment:
-        archived: Set to "Yes" if you no longer need to collect data on this
-          assessment.
         assignment_description: Brief description of the topic of this
           assignment
         assignment_name: For example, "Problem Set 1" or "Quiz 2"
@@ -21,9 +19,6 @@ en:
         target_percentage: The percent of students who should receive a
           satisfactory grade on this problem if, in general, students have
           learned the material. For example, 80 percent.
-      indirect_assessment:
-        archived: Set to "Yes" if you no longer need to collect data on this
-          assessment.
       outcome:
         description: The text of the student learning outcome. The skill or
           ability that the students should have achieved by the time of

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     end
 
     resources :direct_assessments, only: [:new, :create, :edit, :update] do
-      resource :archive, only: [:create]
+      resource :archive, only: [:create, :destroy]
     end
 
     resources :indirect_assessments, only: [:edit, :update]

--- a/db/migrate/20151209222158_add_archived_assessments_count_to_outcomes.rb
+++ b/db/migrate/20151209222158_add_archived_assessments_count_to_outcomes.rb
@@ -1,0 +1,5 @@
+class AddArchivedAssessmentsCountToOutcomes < ActiveRecord::Migration
+  def change
+    add_column :outcomes, :archived_assessments_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151208221025) do
+ActiveRecord::Schema.define(version: 20151209222158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,12 +92,13 @@ ActiveRecord::Schema.define(version: 20151208221025) do
   add_index "outcome_assessments", ["outcome_id"], name: "index_outcome_assessments_on_outcome_id", using: :btree
 
   create_table "outcomes", force: :cascade do |t|
-    t.string   "name",                          null: false
-    t.string   "description",                   null: false
-    t.integer  "course_id",                     null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.integer  "assessments_count", default: 0, null: false
+    t.string   "name",                                   null: false
+    t.string   "description",                            null: false
+    t.integer  "course_id",                              null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.integer  "assessments_count",          default: 0, null: false
+    t.integer  "archived_assessments_count", default: 0, null: false
   end
 
   add_index "outcomes", ["course_id", "name"], name: "index_outcomes_on_course_id_and_name", unique: true, using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -107,7 +107,7 @@ FactoryGirl.define do
   end
 
   factory :subject do
-    department_number { generate(:number) }
+    department
     number
     title { generate(:name) }
   end

--- a/spec/models/direct_assessment_spec.rb
+++ b/spec/models/direct_assessment_spec.rb
@@ -22,4 +22,26 @@ describe DirectAssessment do
       expect(assessment.department).to eq outcome.department
     end
   end
+
+  describe "#archive" do
+    it "archives via the service object" do
+      assessment = DirectAssessment.new
+      allow(AssessmentArchivist).to receive(:archive)
+
+      assessment.archive
+
+      expect(AssessmentArchivist).to have_received(:archive).with(assessment)
+    end
+  end
+
+  describe "#unarchive" do
+    it "unarchives via the service object" do
+      assessment = DirectAssessment.new
+      allow(AssessmentArchivist).to receive(:unarchive)
+
+      assessment.unarchive
+
+      expect(AssessmentArchivist).to have_received(:unarchive).with(assessment)
+    end
+  end
 end

--- a/spec/models/outcome_spec.rb
+++ b/spec/models/outcome_spec.rb
@@ -19,4 +19,12 @@ describe Outcome do
       expect(outcome.reload.assessments_count).to eq 0
     end
   end
+
+  describe "#active_assessments_count" do
+    it "is assessments_count - archived_assessments_count" do
+      outcome = Outcome.new(assessments_count: 5, archived_assessments_count: 3)
+
+      expect(outcome.active_assessments_count).to eq 2
+    end
+  end
 end

--- a/spec/services/assessment_archivist_spec.rb
+++ b/spec/services/assessment_archivist_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe AssessmentArchivist do
+  describe "#archive" do
+    it "archives the assessment and increments the counter on outcomes" do
+      direct_assessment = create(:direct_assessment)
+      outcome = direct_assessment.outcomes.first
+
+      AssessmentArchivist.archive(direct_assessment)
+
+      expect(direct_assessment.reload).to be_archived
+      expect(outcome.reload.archived_assessments_count).to eq 1
+    end
+  end
+
+  describe "#unarchive" do
+    it "unarchives the assessment and decrements the counter on outcomes" do
+      direct_assessment = create(:direct_assessment)
+      outcome = direct_assessment.outcomes.first
+      outcome.increment!(:archived_assessments_count)
+
+      AssessmentArchivist.unarchive(direct_assessment)
+
+      expect(direct_assessment.reload).not_to be_archived
+      expect(outcome.reload.archived_assessments_count).to eq 0
+    end
+
+    it "does not make the counter negative" do
+      direct_assessment = create(:direct_assessment)
+      outcome = direct_assessment.outcomes.first
+
+      AssessmentArchivist.unarchive(direct_assessment)
+
+      expect(direct_assessment.reload).not_to be_archived
+      expect(outcome.reload.archived_assessments_count).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
We were previously tracking the number of assessments associated to an
outcome with a counter cache on `OutcomeAssessment`. With the introduction
of the notion of archived assessments, this count no longer reflects the
number of active assessments.

Getting counter caches to obey conditions is tricky. Since the condition we
care about is binary it's not too bad to do it manually. We keep
`assessments_count` counting the overall number of assessments and add a
service object (AssessmentArchivist) that is responsible for archiving an
unarchiving that tracks a separate count of the number of archived
outcomes. Then it's simple math to get the number of active outcomes.