### PR TITLE
Cache count of results for each assessment

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -2,7 +2,7 @@ class Result < ActiveRecord::Base
   SEMESTERS = ["FA", "JA", "SP"]
   YEARS = (2012..2019).to_a
 
-  belongs_to :assessment, polymorphic: true
+  belongs_to :assessment, polymorphic: true, counter_cache: true
   delegate :department, to: :assessment
 
   validates :assessment_name, presence: true

--- a/db/migrate/20151214183303_add_results_count_to_assessments.rb
+++ b/db/migrate/20151214183303_add_results_count_to_assessments.rb
@@ -1,0 +1,36 @@
+class AddResultsCountToAssessments < ActiveRecord::Migration
+  def change
+    add_column :direct_assessments, :results_count, :integer, null: false, default: 0
+    add_column :indirect_assessments, :results_count, :integer, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE direct_assessments
+          SET results_count = count
+          FROM (
+            SELECT assessment_type, assessment_id, count(*) as count
+            FROM results
+            GROUP BY assessment_type, assessment_id
+          ) AS count_table
+          WHERE
+            assessment_type = 'DirectAssessment' AND
+            assessment_id = direct_assessments.id
+        SQL
+
+        execute <<-SQL
+          UPDATE indirect_assessments
+          SET results_count = count
+          FROM (
+            SELECT assessment_type, assessment_id, count(*) as count
+            FROM results
+            GROUP BY assessment_type, assessment_id
+          ) AS count_table
+          WHERE
+            assessment_type = 'IndirectAssessment' AND
+            assessment_id = indirect_assessments.id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151209222158) do
+ActiveRecord::Schema.define(version: 20151214183303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20151209222158) do
     t.datetime "updated_at",                          null: false
     t.integer  "subject_id",                          null: false
     t.boolean  "archived",            default: false
+    t.integer  "results_count",       default: 0,     null: false
   end
 
   add_index "direct_assessments", ["archived"], name: "index_direct_assessments_on_archived", using: :btree
@@ -76,6 +77,7 @@ ActiveRecord::Schema.define(version: 20151209222158) do
     t.datetime "updated_at",                          null: false
     t.string   "type",                                null: false
     t.boolean  "archived",            default: false
+    t.integer  "results_count",       default: 0,     null: false
   end
 
   add_index "indirect_assessments", ["archived"], name: "index_indirect_assessments_on_archived", using: :btree


### PR DESCRIPTION
This will allow us to more quickly answer the question of "how many
results does this assessment have" or even "how many results do we have
for all active assessments"