### PR TITLE
Fixes to progress bar

### DIFF
--- a/app/assets/stylesheets/refills/_progress_bar.scss
+++ b/app/assets/stylesheets/refills/_progress_bar.scss
@@ -1,10 +1,9 @@
 .progress {
   $progress-bar-height: 4px;
 
-  @include size(100% $progress-bar-height);
+  @include size(150px $progress-bar-height);
   background-color: $light-gray;
   border-radius: $progress-bar-height / 2;
-  min-width: 150px;
   overflow: hidden;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,13 @@
 module ApplicationHelper
   def progress_bar_percentage_width(amount, total)
-    amount = amount.to_f
-    total = total.to_f
-    width = (amount / total) * 100
+    if amount > 0
+      amount = amount.to_f
+      total = total.to_f
+      width = (amount / total) * 100
 
-    number_to_percentage(width, precision: 0)
+      number_to_percentage(width, precision: 0)
+    else
+      amount
+    end
   end
 end


### PR DESCRIPTION
`0.to_f / 0.to_f` returns `NaN`, so the progress bar for `0 / 0` was showing as 100%. Also wanted to limit the width of the progress bar.

Before:
![screen shot 2015-12-15 at 4 14 48 pm](https://cloud.githubusercontent.com/assets/1214346/11824327/065ea038-a347-11e5-8ae9-03158431123c.png)

After:
![screen shot 2015-12-15 at 4 14 59 pm](https://cloud.githubusercontent.com/assets/1214346/11824328/065ef1be-a347-11e5-8b6c-572533388c14.png)
