### PR TITLE
Streamline Manage Assessments flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ tmp
 /config/certs/outcomes-key.pem
 /config/certs/outcomes.cer
 /config/certs/outcomes.jks
+/config/certs/outcomes-dev-cert.pem
+/config/certs/outcomes-dev-key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,4 @@ tmp
 /db/*.sqlite3
 
 .DS_Store
-
-/config/certs/mit.pem
-/config/certs/outcomes-key.pem
-/config/certs/outcomes.cer
-/config/certs/outcomes.jks
-/config/certs/outcomes-dev-cert.pem
-/config/certs/outcomes-dev-key.pem
+/config/certs/

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "therubyracer"
 gem "title"
 gem "turbolinks"
 gem "uglifier"
+gem "autoprefixer-rails"
+gem "font-awesome-rails"
 
 group :development do
   gem "bullet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,9 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     arel (6.0.3)
+    autoprefixer-rails (5.2.0.1)
+      execjs
+      json
     awesome_print (1.6.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -111,6 +114,8 @@ GEM
       railties (>= 3.0.0)
     ffi (1.9.10)
     flutie (2.0.0)
+    font-awesome-rails (4.3.0.0)
+      railties (>= 3.2, < 5.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     gyoku (1.3.1)
@@ -281,6 +286,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
   awesome_print
   bullet
   bundler-audit
@@ -292,6 +298,7 @@ DEPENDENCIES
   email_validator
   factory_girl_rails
   flutie
+  font-awesome-rails
   gssapi!
   high_voltage
   jquery-rails

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -1,0 +1,17 @@
+$(function() {
+  var modalOverlay = $(".modal-overlay");
+  var visibleModalClass = "modal-visible";
+
+  $(".modal-trigger").click(function() {
+    var targetModalName = $(this).data("target-modal-name");
+    var targetModal = $("[data-modal-name=" + targetModalName + "]");
+
+    modalOverlay.addClass(visibleModalClass);
+    targetModal.addClass(visibleModalClass);
+  });
+
+  $(".modal-close, .modal-overlay").click(function() {
+    $(".modal.modal-visible").removeClass(visibleModalClass);
+    modalOverlay.removeClass(visibleModalClass);
+  });
+});

--- a/app/assets/stylesheets/_assessments.scss
+++ b/app/assets/stylesheets/_assessments.scss
@@ -1,4 +1,3 @@
-.assessment-form-end-cta,
 .assessment-details {
   &.card {
     border: 0;
@@ -20,7 +19,7 @@
 }
 
 .assessment-subtitle {
-  color: $medium-gray;
+  color: $brown;
   margin-bottom: $smallest-spacing;
 }
 
@@ -53,31 +52,13 @@
   }
 }
 
-.assessment-form-types {
-  font-size: $large-font-size;
-}
-
-.assessment-form-end-cta {
-  @include align-items(flex-end);
-  @include display(flex);
-  @include flex-basis($large-screen);
-  @include justify-content(space-between);
-  background-color: $light-blue;
-
-  .button {
-    @include flex(1 0 auto);
-    margin-left: $largest-spacing;
-    text-align: center;
-  }
-}
-
 .assessments-dashboard-options {
-  @include display(flex);
-  @include flex-direction(column);
-  @include justify-content(center);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
   @include media($medium-screen-up) {
-    @include flex-direction(row);
+    flex-direction: row;
   }
 
   h6 {
@@ -85,16 +66,11 @@
     color: $base-font-color;
     font-family: $sans-serif-narrow;
   }
-
-  .button {
-    width: 75%;
-  }
 }
 
 .assessments-dashboard-option {
-  @include flex(1);
-  margin-top: $large-spacing;
-  padding: $large-spacing;
+  flex: 1;
+  padding: $base-spacing;
   text-align: center;
 
   @include media($medium-screen-up) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 
 @import "normalize-rails";
+@import "font-awesome";
 @import "bourbon";
 @import "base/grid-settings";
 @import "neat";
@@ -10,6 +11,7 @@
 @import "refills/type_system";
 @import "refills/accordion_tabs_minimal";
 @import "refills/progress_bar";
+@import "refills/modal";
 @import "selectize";
 @import "selectize.default";
 

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -102,7 +102,7 @@ select {
   }
 
   .button-cancel {
-    background-color: $medium-gray;
+    background-color: $brown;
 
     &:hover {
       background-color: $dark-gray;

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -3,7 +3,7 @@ table {
   border-collapse: collapse;
   font-family: $sans-serif-narrow;
   letter-spacing: 0.25px;
-  margin: $large-spacing 0;
+  margin: $base-spacing 0 $large-spacing;
   width: 100%;
 }
 
@@ -45,4 +45,29 @@ caption {
   margin: $small-spacing 0;
   text-align: left;
   width: 75%;
+}
+
+.table-section-header {
+  background-color: $lightest-gray;
+  color: $medium-gray;
+  font-size: $smallest-font-size;
+  font-weight: $bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.inline-action-links {
+  a {
+    border-right: 2px solid $base-border-color;
+    display: inline-block;
+    line-height: $no-line-height;
+    margin-right: $small-spacing;
+    padding-right: $small-spacing;
+
+    &:last-of-type {
+      border-right: 0;
+      margin-right: 0;
+      padding-right: 0;
+    }
+  }
 }

--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -19,6 +19,19 @@ h6 {
   margin: 0 0 $small-spacing;
 }
 
+.headline-with-action {
+  display: flex;
+
+  h1 {
+    flex: 1;
+    margin-right: $small-spacing;
+  }
+
+  .button {
+    align-self: flex-start;
+  }
+}
+
 p {
   margin: 0 0 $small-spacing;
 }

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -2,26 +2,31 @@
 $sans-serif: "Roboto", sans-serif;
 $sans-serif-narrow: "Roboto Condensed", sans-serif;
 $serif: "Domine", serif;
-
 $base-font-family: $sans-serif, $helvetica;
 $heading-font-family: $serif;
 
 // Font Sizes
 $base-font-size: 1em;
+$smallest-font-size: rem(12);
 $small-font-size: rem(14);
 $large-font-size: modular-scale(1, $base-font-size);
 
 // Line height
+$no-line-height: 1;
 $base-line-height: 1.5;
 $heading-line-height: 1.2;
 
-// Other Sizes
+// Border Radius
 $base-border-radius: 3px;
+
+// Spacing
 $base-spacing: $base-line-height * 1em;
 $small-spacing: $base-spacing / 2;
+$smallest-spacing: $base-spacing / 4;
 $large-spacing: $base-spacing * 2;
 $largest-spacing: $base-spacing * 4;
-$smallest-spacing: $base-spacing / 4;
+
+// Other
 $header-height: 62px;
 
 // Colors
@@ -29,15 +34,17 @@ $blue: #1F67A3;
 $light-blue: aliceblue;
 $light-blue-border: shade($light-blue, 5%);
 $dark-gray: #342E2E;
-$medium-gray: #645858;
+$brown: #645858;
+$medium-gray: #aaa;
 $light-gray: #ddd;
+$lightest-gray: #fafafa;
 $white: #fff;
 $required-color: #f58122;
 $mit-red: #a31f34;
 
 // Font Colors
 $base-background-color: #fff;
-$base-font-color: $medium-gray;
+$base-font-color: $brown;
 $action-color: $blue;
 $base-link-color: $action-color !default;
 
@@ -54,7 +61,9 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color, $l
 
 // Zs
 $base-z-index: 0;
-$flashes-z-index: 99999;
+$navigation-z-index: 100;
+$modal-overlay-z-index: 200;
+$modal-z-index: $modal-overlay-z-index + 1;
 
 // Steps
 $breadcrumb-border-color: $light-blue-border;
@@ -63,6 +72,11 @@ $breadcrumb-height: $base-spacing * 2.4;
 $breadcrumb-arrow-color: $breadcrumb-border-color;
 $breadcrumb-background: $base-background-color;
 $breadcrumb-inactive-hover-color: $breadcrumb-background;
-$breadcrumb-color: $medium-gray;
+$breadcrumb-color: $brown;
 $breadcrumb-color-hover: $action-color;
 $breadcrumb-color-active: $breadcrumb-color;
+
+// Transition
+$base-transition-duration: 0.2s;
+$base-transition: all $base-transition-duration ease-in-out;
+$long-transition: all ($base-transition-duration * 2) ease-in-out;

--- a/app/assets/stylesheets/refills/_modal.scss
+++ b/app/assets/stylesheets/refills/_modal.scss
@@ -1,0 +1,52 @@
+.modal-overlay {
+  @include position(fixed, 0);
+  background-color: $brown;
+  opacity: 0;
+  transition: $base-transition;
+  visibility: hidden;
+  z-index: $modal-overlay-z-index;
+
+  &.modal-visible {
+    opacity: 0.9;
+    visibility: visible;
+  }
+}
+
+.modal-close-wrapper {
+  text-align: right;
+}
+
+.modal-close {
+  color: $light-gray;
+  cursor: pointer;
+  font-size: $large-font-size;
+  transition: $base-transition;
+
+  &:hover {
+    color: $blue;
+  }
+}
+
+.modal {
+  @include margin(null auto);
+  @include position(fixed, 0 0 null);
+  background-color: $white;
+  border-radius: $base-border-radius;
+  opacity: 0;
+  padding: $small-spacing;
+  text-align: center;
+  transition: $long-transition;
+  visibility: hidden;
+  width: 90%;
+  z-index: $modal-z-index;
+
+  @include media($medium-screen-up) {
+    width: 700px;
+  }
+
+  &.modal-visible {
+    @include transform(translateY($large-spacing));
+    opacity: 1;
+    visibility: visible;
+  }
+}

--- a/app/assets/stylesheets/refills/_navigation.scss
+++ b/app/assets/stylesheets/refills/_navigation.scss
@@ -22,13 +22,13 @@ header.navigation {
   border-bottom: 1px solid darken($navigation-background, 10);
   min-height: $navigation-height;
   width: 100%;
-  z-index: 999;
+  z-index: $navigation-z-index;
 
   .navigation-wrapper {
     @include clearfix;
     @include outer-container;
     position: relative;
-    z-index: 9999;
+    z-index: $navigation-z-index;
   }
 
   .logo {
@@ -66,7 +66,7 @@ header.navigation {
   nav {
     float: none;
     min-height: $navigation-height;
-    z-index: 9999999;
+    z-index: $navigation-z-index;
 
     @include media ($horizontal-bar-mode) {
       float: left;
@@ -81,7 +81,7 @@ header.navigation {
     overflow: visible;
     padding: 0;
     width: 100%;
-    z-index: 9999;
+    z-index: $navigation-z-index;
 
     &.show {
       display: block;
@@ -102,7 +102,7 @@ header.navigation {
     padding-right: 0.8em;
     text-align: right;
     width: 100%;
-    z-index: 9999;
+    z-index: $navigation-z-index;
 
     @include media ($horizontal-bar-mode) {
       background: transparent;

--- a/app/assets/stylesheets/refills/_progress_bar.scss
+++ b/app/assets/stylesheets/refills/_progress_bar.scss
@@ -8,7 +8,7 @@
 }
 
 .progress-bar {
-  background-color: $medium-gray;
+  background-color: $brown;
   height: 100%;
 }
 
@@ -16,7 +16,7 @@
   color: darken($light-gray, 20%);
   font-family: $sans-serif;
 
-  span {
-    color: $medium-gray;
+  .nonzero-amount {
+    color: $brown;
   }
 }

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -3,8 +3,10 @@
 }
 
 ul.assessment-details {
-  @extend %default-ul;
-  margin-bottom: $base-spacing;
+  @include margin($large-spacing null);
+  @include padding(null $large-spacing);
+  line-height: 2em;
+  list-style-type: disc;
 }
 
 .period .input {

--- a/app/controllers/manage_assessments/dashboard_controller.rb
+++ b/app/controllers/manage_assessments/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class ManageAssessments::DashboardController < ApplicationController
   def show
-    @courses = policy_scope(Course)
+    @courses = policy_scope(Course.includes(:outcomes_with_metadata))
     authorize(:generic, :view_assessments?)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def javascript_void
+    "javascript:void(0)"
+  end
+
   def progress_bar_percentage_width(amount, total)
     if amount > 0
       amount = amount.to_f

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,6 +18,14 @@ class Course < ActiveRecord::Base
     update_column(:has_custom_outcomes, true)
   end
 
+  def active_assessments_count
+    outcomes_with_metadata.to_a.sum(&:active_assessments_count)
+  end
+
+  def active_assessments_with_results_count
+    outcomes_with_metadata.to_a.sum(&:active_assessments_with_results_count)
+  end
+
   def to_s
     "#{number}: #{name}"
   end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -13,7 +13,7 @@ class CoursePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      Course.
+      scope.
         order(:id).
         joins(:department).
         where(departments: { slug: user.department_slugs })

--- a/app/views/application/_progress_bar.erb
+++ b/app/views/application/_progress_bar.erb
@@ -1,4 +1,7 @@
 <div class="progress">
   <div class="progress-bar" style="width: <%= progress_bar_percentage_width(amount, total) %>"></div>
 </div>
-<small class="progress-label"><span><%= amount %></span> / <%= total %></small>
+
+<small class="progress-label">
+  <span class="<%= 'nonzero-amount' if amount != 0 %>"><%= amount %></span> / <%= total %>
+</small>

--- a/app/views/layouts/_modal.html.erb
+++ b/app/views/layouts/_modal.html.erb
@@ -1,0 +1,9 @@
+<div class="modal-overlay"></div>
+
+<div class="modal" data-modal-name="<%= modal_name %>">
+  <div class="modal-close-wrapper">
+    <%= fa_icon "close", class: "modal-close" %>
+  </div>
+
+  <%= yield %>
+</div>

--- a/app/views/manage_assessments/_new_assessment_modal.html.erb
+++ b/app/views/manage_assessments/_new_assessment_modal.html.erb
@@ -1,0 +1,25 @@
+<%= render layout: '/layouts/modal', locals: { modal_name: "create-assessment" } do %>
+  <h2><%= t("manage_assessments.new_assessment_modal.create_new_assessment") %></h2>
+
+  <div class="assessments-dashboard-options">
+    <div class="assessments-dashboard-option">
+      <h6><%= t("manage_assessments.new_assessment_modal.by") %></h6>
+      <h1><%= t("manage_assessments.new_assessment_modal.subject") %></h1>
+      <%= link_to t("manage_assessments.new_assessment_modal.get_started"),
+        new_manage_assessments_direct_assessment_path,
+        class: "button",
+        data: { role: "start-direct-assessment" }
+      %>
+    </div>
+
+    <div class="assessments-dashboard-option">
+      <h6><%= t("manage_assessments.new_assessment_modal.by") %></h6>
+      <h1><%= t("manage_assessments.new_assessment_modal.course") %></h1>
+      <%= link_to t("manage_assessments.new_assessment_modal.get_started"),
+        manage_assessments_courses_path,
+        class: "button",
+        data: { role: "start-indirect-assessment" }
+      %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/manage_assessments/assessments/_direct_assessments.html.erb
+++ b/app/views/manage_assessments/assessments/_direct_assessments.html.erb
@@ -1,27 +1,23 @@
-<h4>Direct Assessments</h4>
-<table id="direct_assessments">
-  <tr>
-    <th><%= t(".subject") %></th>
-    <th><%= t(".name") %></th>
-    <th><%= t(".description") %></th>
-    <th><%= t(".minimum") %></th>
-    <th><%= t(".target") %></th>
-    <th></th>
-    <th></th>
-  </tr>
-  <% outcome.direct_assessments.each do |assessment| %>
-    <%= content_tag_for :tr, assessment do %>
-      <td><%= assessment.subject %></td>
-      <td><%= assessment.name %></td>
-      <td><%= assessment.description %></td>
-      <td><%= assessment.minimum_requirement %></td>
-      <td><%= assessment.target_percentage %></td>
-      <td>
-        <% if policy(:generic).create_assessments? %>
-          <%= link_to t(".edit"), edit_manage_assessments_direct_assessment_path(assessment) %>
-        <% end %>
-      </td>
-      <td><%= link_to t(".view_results"), manage_results_direct_assessment_path(assessment) %></td>
-    <% end %>
+<tr>
+  <td colspan="7" class="table-section-header" title="<%= outcome.description %>">
+    <%= t(".outcome_table_section_header",
+      outcome: outcome.name,
+      count: pluralize(outcome.direct_assessments.count, t(".assessment"))) %>
+  </td>
+</tr>
+
+<% outcome.direct_assessments.each do |assessment| %>
+  <%= content_tag_for :tr, assessment do %>
+    <td><%= assessment.subject %></td>
+    <td><%= assessment.name %> - <%= assessment.description %></td>
+    <td><%= assessment.minimum_requirement %></td>
+    <td><%= assessment.target_percentage %></td>
+    <td class="inline-action-links">
+      <% if policy(:generic).create_assessments? %>
+        <%= link_to t(".edit"), edit_manage_assessments_direct_assessment_path(assessment) %>
+      <% end %>
+
+      <%= link_to t(".view"), manage_results_direct_assessment_path(assessment) %>
+    </td>
   <% end %>
-</table>
+<% end %>

--- a/app/views/manage_assessments/assessments/_indirect_assessments.html.erb
+++ b/app/views/manage_assessments/assessments/_indirect_assessments.html.erb
@@ -1,29 +1,27 @@
-<h4>Indirect Assessments</h4>
-<table id="indirect_assessments">
-  <tr>
-    <th><%= t(".name") %></th>
-    <th><%= t(".description") %></th>
-    <th><%= t(".survey_question") %></th>
-    <th><%= t(".minimum") %></th>
-    <th><%= t(".target") %></th>
-    <th><%= t(".type") %></th>
-    <th></th>
-    <th></th>
-  </tr>
-  <% outcome.indirect_assessments.each do |assessment| %>
-    <%= content_tag_for :tr, assessment do %>
-      <td><%= assessment.name %></td>
-      <td><%= assessment.description %></td>
-      <td><%= assessment.survey_question %></td>
-      <td><%= assessment.minimum_requirement %></td>
-      <td><%= assessment.target_percentage %></td>
-      <td><%= assessment_type(assessment) %></td>
-      <td>
-        <% if policy(:generic).create_assessments? %>
-          <%= link_to t(".edit"), edit_manage_assessments_indirect_assessment_path(assessment) %>
-        <% end %>
-      </td>
-      <td><%= link_to t(".view_results"), manage_results_indirect_assessment_path(assessment) %></td>
-    <% end %>
+<tr>
+  <td colspan="7" class="table-section-header" title="<%= outcome.description %>">
+    <%= t(".outcome_table_section_header",
+      outcome: outcome.name,
+      count: pluralize(outcome.indirect_assessments.count, t(".assessment"))) %>
+  </td>
+</tr>
+
+<% outcome.indirect_assessments.each do |assessment| %>
+  <%= content_tag_for :tr, assessment do %>
+    <td><%= assessment.name %></td>
+    <td><%= assessment.description %></td>
+    <td><%= assessment.survey_question %></td>
+    <td><%= assessment.minimum_requirement %></td>
+    <td><%= assessment.target_percentage %></td>
+    <td><%= assessment_type(assessment) %></td>
+
+    <td class="inline-action-links">
+      <% if policy(:generic).create_assessments? %>
+        <%= link_to t(".edit"), edit_manage_assessments_indirect_assessment_path(assessment) %>
+      <% end %>
+
+      <%= link_to t(".view"), manage_results_indirect_assessment_path(assessment) %>
+    </td>
+    </td>
   <% end %>
-</table>
+<% end %>

--- a/app/views/manage_assessments/assessments/index.html.erb
+++ b/app/views/manage_assessments/assessments/index.html.erb
@@ -1,22 +1,51 @@
 <% tab(TabHelper::ASSESSMENTS) %>
 
-<h1><%= t(".heading", name: @course) %></h1>
-<% if policy(:generic).create_assessments? %>
-  <%= link_to t(".add_assessment"), manage_assessments_root_path, class: "button" %>
-<% end %>
-<br>
+<div class="headline-with-action">
+  <h1><%= t(".heading", name: @course) %></h1>
 
-<% @outcomes.each do |outcome| %>
-  <% if outcome.direct_assessments.any? || outcome.indirect_assessments.any? %>
-    <h2>Outcome <%= outcome %> (<%= t(".assessments_count", count: outcome.assessments_count) %>)</h2>
+  <% if policy(:generic).create_assessments? %>
+    <%= link_to t(".create_new_assessment"), javascript_void,
+      class: "button modal-trigger",
+      data: { target_modal_name: "create-assessment" } %>
+
+    <%= render "manage_assessments/new_assessment_modal" %>
+  <% end %>
+</div>
+
+<h2><%= t(".direct_assessments") %></h2>
+
+<table id="direct_assessments">
+  <tr>
+    <th><%= t(".subject") %></th>
+    <th><%= t(".assignment") %></th>
+    <th><%= t(".minimum") %></th>
+    <th><%= t(".target") %></th>
+    <th><%= t(".actions") %></th>
+  </tr>
+
+  <% @outcomes.each do |outcome| %>
     <% if outcome.direct_assessments.any? %>
       <%= render "direct_assessments", outcome: outcome %>
     <% end %>
+  <% end %>
+</table>
 
-    <br>
+<h2><%= t(".indirect_assessments") %></h2>
 
+<table id="indirect_assessments">
+  <tr>
+    <th><%= t(".name") %></th>
+    <th><%= t(".description") %></th>
+    <th><%= t(".survey_question") %></th>
+    <th><%= t(".minimum") %></th>
+    <th><%= t(".target") %></th>
+    <th><%= t(".type") %></th>
+    <th><%= t(".actions") %></th>
+  </tr>
+
+  <% @outcomes.each do |outcome| %>
     <% if outcome.indirect_assessments.any? %>
       <%= render "indirect_assessments", outcome: outcome %>
     <% end %>
   <% end %>
-<% end %>
+</table>

--- a/app/views/manage_assessments/dashboard/show.html.erb
+++ b/app/views/manage_assessments/dashboard/show.html.erb
@@ -1,34 +1,47 @@
 <% tab(TabHelper::ASSESSMENTS) %>
-<% if policy(:generic).create_assessments? %>
-  <h2>Create New Assessment</h2>
-  <div class="assessments-dashboard-options">
-    <div class="assessments-dashboard-option">
-      <h6><%= t(".by") %></h6>
-      <h1><%= t(".subject") %></h1>
-      <%= link_to t(".get_started"),
-        new_manage_assessments_direct_assessment_path,
-        class: "button",
-        data: { role: "start-direct-assessment" }
-      %>
-    </div>
 
-    <div class="assessments-dashboard-option">
-      <h6><%= t(".by") %></h6>
-      <h1><%= t(".course") %></h1>
-      <%= link_to t(".get_started"),
-        manage_assessments_courses_path,
-        class: "button",
-        data: { role: "start-indirect-assessment" }
-      %>
-    </div>
-  </div>
-<% end %>
+<div class="headline-with-action">
+  <h1><%= t(".title") %></h1>
 
-<h2>Manage Existing Assessments</h2>
+  <% if policy(:generic).create_assessments? %>
+    <%= link_to t(".create_new_assessment"), javascript_void,
+      class: "button modal-trigger",
+      data: { target_modal_name: "create-assessment" } %>
+
+    <%= render "manage_assessments/new_assessment_modal" %>
+  <% end %>
+</div>
+
 <div>
-  <ul>
-    <% @courses.each do |course| %>
-      <li><%= link_to course, manage_assessments_course_assessments_path(course) %></li>
-    <% end %>
-  </ul>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t(".number") %></th>
+        <th><%= t(".name")%></th>
+        <th><%= t(".assessments") %></th>
+        <th><%= t(".actions") %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @courses.each do |course| %>
+        <tr>
+          <td><strong><%= course.number %></strong></td>
+          <td><%= course.name %></td>
+          <td><%= render "progress_bar",
+            amount: course.active_assessments_with_results_count,
+            total: course.active_assessments_count %></td>
+          <td>
+            <% if course.active_assessments_count > 0 %>
+              <%= link_to t(".view_assessments"), manage_assessments_course_assessments_path(course) %>
+            <% elsif policy(:generic).create_assessments? %>
+              <%= link_to t(".create_new_assessment"), javascript_void,
+                class: "modal-trigger",
+                data: { target_modal_name: "create-assessment" } %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/app/views/manage_results/direct_assessments/show.html.erb
+++ b/app/views/manage_results/direct_assessments/show.html.erb
@@ -1,17 +1,26 @@
 <% tab(TabHelper::DATA_ENTRY) %>
 
 <h1><%= @assessment %></h1>
+
+<%= link_to t(".edit"),
+  edit_manage_assessments_direct_assessment_path(@assessment),
+  class: "button" %>
+
+<%= link_to t(".archive"),
+  manage_assessments_direct_assessment_archive_path(@assessment),
+  class: "button" %>
+
 <%= assessment_details(@assessment) %>
 
 <section class="results">
   <h2>Results</h2>
-  <%= render "results", results: @assessment.results %>
-
   <% if policy(@assessment).create_results? %>
     <%= link_to t(".add_result"),
       new_manage_results_direct_assessment_result_path(@assessment),
       class: "button" %>
   <% end %>
+
+  <%= render "results", results: @assessment.results %>
 </section>
 
 <section class="outcomes">

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -60,7 +60,7 @@ en:
         assessments: Assessment Coverage
         create_new_assessment: Create New Assessment
         intro_paragraph:
-          link: add an outcome
+          link: set up outcomes
           text_html: If you do not see your course listed below then you need to %{link} for that course.
         name: Name
         no_assessments: No Assessments

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -22,38 +22,47 @@ en:
         survey_results_description: The outcome will be assessed based on the results
           from a student survey
       direct_assessments:
-        description: Assignment Description
+        assessment: Assessment
         edit: Edit
-        minimum: Minimum Grade
-        name: Assignment Name
-        subject: Subject
-        target: Target Percentage
-        view_results: View and Add Results
+        outcome_table_section_header: Outcome %{outcome} (%{count})
+        view: View
       index:
-        add_assessment: Add new assessment
-        heading: Assessments for %{name}
-        assessments_count:
-          one: 1 assessment
-          other: "%{count} assessments"
-      indirect_assessments:
+        actions: Actions
+        assignment: Assignment
+        create_new_assessment: Create New Assessment
         description: Description
-        edit: Edit
-        minimum: Minimum Category
+        direct_assessments: Direct Assessments
+        heading: Assessments for %{name}
+        indirect_assessments: Indirect Assessments
+        minimum: Minimum Grade
         name: Name
+        subject: Subject
         survey_question: Survey Question
         target: Target Percentage
         type: Type
-        view_results: View and Add Results
+      indirect_assessments:
+        assessment: Assessment
+        edit: Edit
+        outcome_table_section_header: Outcome %{outcome} (%{count})
+        view: View
       outcomes:
         outcome:
           assess: New Assessment
           details: Details
     dashboard:
-      show:
+      create_assessment_modal:
         by: by
         course: Course
-        get_started: Get started
         subject: Subject
+        get_started: Get started
+      show:
+        actions: Actions
+        assessments: Assessment Coverage
+        name: Name
+        create_new_assessment: Create New Assessment
+        number: Number
+        title: Manage Assessments for Your Courses
+        view_assessments: View Assessments
     courses:
       index:
         actions: Actions
@@ -82,3 +91,9 @@ en:
           survey: New Survey Assessment
       update:
         success: Assessment updated successfully.
+    new_assessment_modal:
+      by: By
+      course: Course
+      create_new_assessment: Create New Assessment
+      get_started: Get Started
+      subject: Subject

--- a/config/locales/manage_results.en.yml
+++ b/config/locales/manage_results.en.yml
@@ -16,6 +16,8 @@ en:
         year: Year
       show:
         add_result: Add result
+        archive: Archive
+        edit: Edit
     indirect_assessments:
       outcomes:
         heading: Outcomes Covered by This Assessment

--- a/spec/features/ta_creates_a_result_spec.rb
+++ b/spec/features/ta_creates_a_result_spec.rb
@@ -15,7 +15,7 @@ feature "TA creates a result" do
     expect(page).to have_content assessment.description
     expect(page).to have_content assessment.subject
 
-    click_on "View and Add Results"
+    click_on "View"
     click_on "Add result"
 
     expect(find_field("result_assessment_name").value).to eq assessment.name
@@ -42,7 +42,7 @@ feature "TA creates a result" do
     user = user_with_results_access_to(assessment.department)
 
     visit manage_assessments_course_assessments_path(assessment.outcomes.first.course, as: user)
-    click_on "View and Add Results"
+    click_on "View"
 
     expect(page).to have_content assessment.name
     expect(page).to have_content assessment.description

--- a/spec/features/user_creates_direct_assessment_spec.rb
+++ b/spec/features/user_creates_direct_assessment_spec.rb
@@ -15,8 +15,8 @@ feature "User creates a direct assessment" do
     click_link course.name
 
     expect(page).to have_content subject_
-    expect(page).to have_content outcomes.first
-    expect(page).to have_content outcomes.last
+    expect(page).to have_content "Outcome #{outcomes.first.name} (#{outcomes.first.direct_assessments.count} Assessment)"
+    expect(page).to have_content "Outcome #{outcomes.last.name} (#{outcomes.last.direct_assessments.count} Assessment)"
     expect(page).to have_content "Problem Set 1"
   end
 

--- a/spec/features/user_deletes_a_result_spec.rb
+++ b/spec/features/user_deletes_a_result_spec.rb
@@ -26,9 +26,9 @@ feature "User deletes a result" do
 
     visit root_path(as: user)
     click_on "Manage Assessments"
-    click_on course
+    click_on "View Assessments"
     within("#indirect_assessment_#{assessment.id}") do
-      click_on "View and Add Results"
+      click_on "View"
     end
     within("#result_#{result.id}") do
       click_on "Delete"

--- a/spec/features/user_updates_direct_assessment_spec.rb
+++ b/spec/features/user_updates_direct_assessment_spec.rb
@@ -23,8 +23,8 @@ feature "User updates a direct assessment" do
     click_on "Submit"
 
     expect(page).to have_content assessment.subject
-    expect(page).to have_content outcome
-    expect(page).to have_content other_outcome
+    expect(page).to have_content "Outcome #{outcome.name} (#{outcome.direct_assessments.count} Assessment)"
+    expect(page).to have_content "Outcome #{other_outcome.name} (#{outcome.direct_assessments.count} Assessment)"
     expect(page).to have_content("85")
   end
 end

--- a/spec/features/user_updates_result_spec.rb
+++ b/spec/features/user_updates_result_spec.rb
@@ -28,9 +28,9 @@ feature "User updates result" do
 
     visit root_path(as: user)
     click_on "Manage Assessments"
-    click_on course
+    click_on "View Assessments"
     within("#indirect_assessment_#{assessment.id}") do
-      click_on "View and Add Results"
+      click_on "View"
     end
     within("#result_#{result.id}") do
       click_on "Edit"


### PR DESCRIPTION
- Introduced a modal for creating a new assessment. This makes landing page for "Managing Assessments" simpler. The same button is also carried into the "Managing Assessments for [Course]" view, which helps to keep that action consistent and eliminates the need for the user to be redirected back to the landing page from that view in order to create a new assessment.
![new_assessment_modal](https://cloud.githubusercontent.com/assets/1214346/11854090/949c0d04-a40f-11e5-84bf-b878fbe05eb0.gif)
![screencapture-localhost-3000-manage_assessments-1450300090635](https://cloud.githubusercontent.com/assets/1214346/11854026/503c3e90-a40f-11e5-9207-da69b772a76d.png)

- Restructured the "Manage Assessments for [Courses]" view to have two tables: direct and indirect. Then within those the assessments are separated by outcome. The outcome description is no longer present, but you can hover over the title row (Outcome A (1 Assessment)) and the description will show up. If that needs to be more prevalent than I can make a fix for that. Overall it takes up less room and is easier to read while representing the same information as before. Since Derek is working on the gradebook and probably shouldn't fuss with filtering the page right now, I think this is a good first step towards a cleaner page.

- Added "Edit" and "Archive" actions to the assessment. Also moved the "Add Results" button above the results table. When there are more results the button won't get buried farther down the page.
![screen shot 2015-12-16 at 2 29 26 pm](https://cloud.githubusercontent.com/assets/1214346/11851627/9082b7da-a401-11e5-9757-813a419dacdc.png)
