### PR TITLE
Only show active assessments

### DIFF
--- a/app/controllers/manage_assessments/assessments_controller.rb
+++ b/app/controllers/manage_assessments/assessments_controller.rb
@@ -2,8 +2,8 @@ class ManageAssessments::AssessmentsController < ApplicationController
   def index
     @course = Course.find(params[:course_id])
     @outcomes = policy_scope(@course.outcomes).
-      includes(direct_assessments: :subject).
-      includes(:indirect_assessments)
+      includes(active_direct_assessments: :subject).
+      includes(:active_indirect_assessments)
   end
 
   def new

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -13,6 +13,16 @@ class Outcome < ActiveRecord::Base
     through: :outcome_assessments,
     source: :assessment,
     source_type: "IndirectAssessment"
+  has_many :active_direct_assessments,
+    -> { where(archived: false) },
+    through: :outcome_assessments,
+    source: :assessment,
+    source_type: "DirectAssessment"
+  has_many :active_indirect_assessments,
+    -> { where(archived: false) },
+    through: :outcome_assessments,
+    source: :assessment,
+    source_type: "IndirectAssessment"
 
   accepts_nested_attributes_for :alignments,
     reject_if: ->(attributes) { attributes[:level].blank? },

--- a/app/views/manage_assessments/assessments/index.html.erb
+++ b/app/views/manage_assessments/assessments/index.html.erb
@@ -24,7 +24,7 @@
   </tr>
 
   <% @outcomes.each do |outcome| %>
-    <% if outcome.direct_assessments.any? %>
+    <% if outcome.active_direct_assessments.any? %>
       <%= render "direct_assessments", outcome: outcome %>
     <% end %>
   <% end %>
@@ -44,7 +44,7 @@
   </tr>
 
   <% @outcomes.each do |outcome| %>
-    <% if outcome.indirect_assessments.any? %>
+    <% if outcome.active_indirect_assessments.any? %>
       <%= render "indirect_assessments", outcome: outcome %>
     <% end %>
   <% end %>


### PR DESCRIPTION
When a user views assessments for a given course, they do not need to
see archived assessments.

This leaves users with no easy way to view a list of things that are
archived and then unarchive them. There's a separate trello card for
unarchiving with some ideas already discussed.