### PR TITLE
Add assessment progress bar to manage outcomes

### DIFF
--- a/app/views/manage_outcomes/dashboard/_courses_table.html.erb
+++ b/app/views/manage_outcomes/dashboard/_courses_table.html.erb
@@ -6,6 +6,9 @@
     <tr>
       <th class="number"><%= t(".number") %></th>
       <th class="name"><%= t(".name") %></th>
+      <% if show_assessment_coverage %>
+        <th class="assessment-coverage"><%= t(".assessment_coverage") %></th>
+      <% end %>
       <th class="actions"><%= t(".actions") %></th>
     </tr>
   </thead>
@@ -14,9 +17,12 @@
       <tr>
         <td><%= course.number %></td>
         <td><%= course.name %></td>
-        <td>
-          <%= render action_partial, course: course %>
-        </td>
+        <% if show_assessment_coverage %>
+          <td><%= render "progress_bar",
+            amount: course.active_assessments_with_results_count,
+            total: course.active_assessments_count %></td>
+        <% end %>
+        <td><%= render action_partial, course: course %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/manage_outcomes/dashboard/show.html.erb
+++ b/app/views/manage_outcomes/dashboard/show.html.erb
@@ -10,7 +10,8 @@
     caption: t(".captions.without_outcomes_html"),
     table_class: "without-outcomes",
     title: t(".titles.without_outcomes"),
-    action_partial: "without_outcomes_actions" %>
+    action_partial: "without_outcomes_actions",
+    show_assessment_coverage: false %>
 <% end %>
 
 <% if @outcomes_dashboard.unaligned_courses.present? %>
@@ -19,7 +20,8 @@
     caption: t(".captions.unaligned_outcomes_html"),
     table_class: "unaligned",
     title: t(".titles.unaligned_outcomes"),
-    action_partial: "unaligned_outcomes_actions" %>
+    action_partial: "unaligned_outcomes_actions",
+    show_assessment_coverage: true %>
 <% end %>
 
 <% if @outcomes_dashboard.aligned_courses.present? %>
@@ -28,5 +30,6 @@
     caption: t(".captions.aligned_outcomes_html"),
     table_class: "fully-aligned",
     title: t(".titles.aligned_outcomes"),
-    action_partial: "aligned_outcomes_actions" %>
+    action_partial: "aligned_outcomes_actions",
+    show_assessment_coverage: true %>
 <% end %>

--- a/config/locales/manage_outcomes.en.yml
+++ b/config/locales/manage_outcomes.en.yml
@@ -7,6 +7,7 @@ en:
         view_outcomes: View Outcomes
       courses_table:
         actions: Actions
+        assessment_coverage: Assessment Coverage
         name: Name
         number: Number
       show:
@@ -67,7 +68,7 @@ en:
       outcomes:
         actions: Actions
         add_outcome: Add A Custom Outcome
-        assessments: Assessments
+        assessments: Assessment Coverage
         edit_outcome: Edit Outcome
         outcome: Outcome
       unaligned_standard_outcomes:


### PR DESCRIPTION
Adding assessment progress bar to Manage Outcomes landing.

![screen shot 2015-12-21 at 10 03 26 am](https://cloud.githubusercontent.com/assets/1214346/11933477/1bec6566-a7ca-11e5-8f21-984a36e3322a.png)
