### PR TITLE
Add result activity feed

### DIFF
--- a/app/assets/images/icon_create.svg
+++ b/app/assets/images/icon_create.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9 7V5H7v2H5v2h2v2h2V9h2V7H9zm-1 9c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8z" fill="#417505" fill-rule="evenodd"/>
+</svg>

--- a/app/assets/images/icon_edit.svg
+++ b/app/assets/images/icon_edit.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M11 0L0 11v5h5L16 5l-5-5zM2 11h2v1h1v2H2v-3z" fill="#645858" fill-rule="evenodd"/>
+</svg>

--- a/app/assets/stylesheets/_activity_feed.scss
+++ b/app/assets/stylesheets/_activity_feed.scss
@@ -1,0 +1,43 @@
+.activity-feed {
+  border-top: $base-border;
+}
+
+.activity-header-date {
+  color: $mit-red;
+}
+
+.activity-icon {
+  $icon-size: 16px;
+  $padding: $base-spacing;
+
+  width: em($icon-size) + $padding;
+
+  img {
+    display: block;
+  }
+}
+
+.activity-event-and-subject {
+  @include padding($base-spacing null);
+}
+
+.activity-event {
+  display: block;
+  font-family: $serif;
+  margin-bottom: $smallest-spacing;
+
+  a {
+    display: inline;
+  }
+}
+
+.activity-subject {
+  color: $medium-gray;
+  display: block;
+  font-size: $small-font-size;
+}
+
+.activity-header-count,
+.activity-time {
+  text-align: right;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "selectize";
 @import "selectize.default";
 
+@import "activity_feed";
 @import "assessment_types";
 @import "assessments_for_course";
 @import "assessments";

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -10,15 +10,7 @@ table {
 
 th,
 td {
-  padding: $small-spacing $base-spacing;
-
-  &:first-of-type {
-    padding-left: $small-spacing;
-  }
-
-  &:last-of-type {
-    padding-right: $small-spacing;
-  }
+  padding: $small-spacing;
 }
 
 th {
@@ -57,7 +49,7 @@ caption {
   color: $medium-gray;
   font-size: $smallest-font-size;
   font-weight: $bold;
-  letter-spacing: 1px;
+  letter-spacing: $base-letter-spacing;
   text-transform: uppercase;
 }
 

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -57,6 +57,9 @@ $base-link-color: $action-color !default;
 // Font Weight
 $bold: 700;
 
+// Letter Spacing
+$base-letter-spacing: 1px;
+
 // Border
 $base-border-color: $light-gray;
 $base-border: 1px solid $base-border-color;

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,6 @@
+class ActivitiesController < ApplicationController
+  def index
+    activities = policy_scope(Activity.includes(:user, :result).limit(100))
+    @activity_feed = ActivityFeed.new(activities)
+  end
+end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,11 @@
+module DateHelper
+  def relative_date(date)
+    if date >= Date.today
+      t("helpers.today")
+    elsif date == Date.yesterday
+      t("helpers.yesterday")
+    else
+      date.strftime("%m-%d-%Y")
+    end
+  end
+end

--- a/app/helpers/result_helper.rb
+++ b/app/helpers/result_helper.rb
@@ -1,0 +1,9 @@
+module ResultHelper
+  def result_assessment_path(result)
+    if result.assessment_type == 'DirectAssessment'
+      manage_results_direct_assessment_path(result.assessment_id)
+    else
+      manage_results_indirect_assessment_path(result.assessment_id)
+    end
+  end
+end

--- a/app/helpers/tab_helper.rb
+++ b/app/helpers/tab_helper.rb
@@ -2,6 +2,7 @@ module TabHelper
   OUTCOMES = :outcomes
   ASSESSMENTS = :assessments
   DATA_ENTRY = :data_entry
+  ACTIVITY_FEED = :activity_feed
   REPORTS = :reports
 
   def tab(value)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,31 @@
+class Activity < PaperTrail::Version
+  default_scope { where(item_type: "Result") }
+
+  belongs_to :user, foreign_key: :whodunnit
+  belongs_to :result, foreign_key: :item_id
+
+  delegate :username, to: :user, allow_nil: true
+
+  def date
+    created_at.to_date
+  end
+
+  def subject
+    case result.assessment
+    when DirectAssessment
+      result.assessment.subject.to_s
+    else
+      "Indirect Assessment"
+    end
+  end
+
+  def time_formatted
+    created_at.strftime("%-I:%M %p")
+  end
+
+  private
+
+  def read_only?
+    true
+  end
+end

--- a/app/models/activity_feed.rb
+++ b/app/models/activity_feed.rb
@@ -1,0 +1,13 @@
+class ActivityFeed
+  def initialize(activities)
+    @activities = activities
+  end
+
+  def grouped_activities
+    @_days = activities.group_by(&:date)
+  end
+
+  private
+
+  attr_reader :activities
+end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -2,8 +2,10 @@ class Result < ActiveRecord::Base
   SEMESTERS = ["FA", "JA", "SP"]
   YEARS = (2012..2019).to_a
 
+  before_save :denormalize_department
+
   belongs_to :assessment, polymorphic: true, counter_cache: true
-  delegate :department, to: :assessment
+  belongs_to :department
 
   validates :assessment_name, presence: true
   validates :assessment_description, presence: true
@@ -15,4 +17,14 @@ class Result < ActiveRecord::Base
     uniqueness: { scope: [:assessment_type, :semester, :year] }
 
   has_paper_trail
+
+  def name
+    "#{assessment_name} - #{assessment_description}"
+  end
+
+  private
+
+  def denormalize_department
+    self.department = assessment.department
+  end
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,0 +1,10 @@
+class ActivityPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.
+        joins(result: :department).
+        where(departments: { slug: user.department_slugs }).
+        order(created_at: :desc)
+    end
+  end
+end

--- a/app/policies/result_policy.rb
+++ b/app/policies/result_policy.rb
@@ -1,6 +1,6 @@
 class ResultPolicy < ApplicationPolicy
   def create?
-    user.manage_results?(record.department)
+    user.manage_results?(record.assessment.department)
   end
 
   def update?

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,0 +1,31 @@
+<tr>
+  <td class="activity-icon">
+    <% if activity.event == "create" %>
+      <%= image_tag "icon_create.svg" %>
+    <% else %>
+      <%= image_tag "icon_edit.svg" %>
+    <% end %>
+  </td>
+
+  <td class="activity-event-and-subject">
+    <span class="activity-event">
+      <%= t(
+        ".event.#{activity.event}_html",
+        assessment: link_to(
+          activity.result.name,
+          result_assessment_path(activity.result),
+        ),
+      ) %>
+    </span>
+
+    <span class="activity-subject"><%= activity.subject %></span>
+  </td>
+
+  <td class="activity-user">
+    <%= activity.username %>
+  </td>
+
+  <td class="activity-time">
+    <%= activity.time_formatted %>
+  </td>
+</tr>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -1,0 +1,14 @@
+<% tab(TabHelper::ACTIVITY_FEED) %>
+
+<h1><%= t(".heading") %></h1>
+
+<table class="activity-feed">
+  <% @activity_feed.grouped_activities.each do |date, activities| %>
+    <tr class="table-section-header">
+      <td class="activity-header-date" colspan="3"><%= relative_date(date) %></td>
+      <td class="activity-header-count"><%= t(".activity_count", count: activities.size) %></td>
+    </tr>
+
+    <%= render activities %>
+  <% end %>
+</table>

--- a/app/views/application/_tabs.html.erb
+++ b/app/views/application/_tabs.html.erb
@@ -14,6 +14,11 @@
       manage_results_subjects_path,
       class: tab_class(TabHelper::DATA_ENTRY) %>
   </li>
+  </li>
+    <%= link_to t(".activity_feed"),
+      activities_path,
+      class: tab_class(TabHelper::ACTIVITY_FEED) %>
+  </li>
   <li>
     <%= link_to t(".reports"),
       reports_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,16 @@ en:
       other_assessment: Other Assessment
       participation: Program Participation
       survey: Survey
+  activities:
+    activity:
+      event:
+        create_html: Results created for %{assessment}
+        update_html: Results updated for %{assessment}
+    index:
+      activity_count:
+        one: 1 Change
+        other: "%{count} Changes"
+      heading: Activity Feed
   application:
     navigation:
       assessments: Assessments
@@ -50,6 +60,7 @@ en:
       outcomes: Outcomes
       recording_data: Recording Data
     tabs:
+      activity_feed: Activity Feed
       assessments: Manage Assessments
       data: Record Data
       outcomes: Manage Outcomes
@@ -63,6 +74,8 @@ en:
   helpers:
     cancel_button: Cancel
     jon_daries_html: Jon Daries in Institutional Research at %{email}
+    today: Today
+    yesterday: Yesterday
   layouts:
     documentation_side_nav:
       assessments: Assessments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,8 @@ Rails.application.routes.draw do
     root to: "courses#index", as: :reports
   end
 
+  resources :activities, only: [:index]
+
   get "/pages/*id" => "pages#show", as: :page, format: false
   root "manage_outcomes/dashboard#show"
 end

--- a/db/migrate/20151223013448_add_department_to_results.rb
+++ b/db/migrate/20151223013448_add_department_to_results.rb
@@ -1,0 +1,50 @@
+class AddDepartmentToResults < ActiveRecord::Migration
+  def change
+    add_column :results, :department_id, :integer, index: true
+
+    reversible do |dir|
+      dir.up do
+        populate_results_department_for_direct_assessments
+        populate_results_department_for_indirect_assessments
+      end
+    end
+
+    change_column_null :results, :department_id, :false
+  end
+
+  private
+
+  def populate_results_department_for_direct_assessments
+    execute <<-SQL
+      UPDATE results SET department_id = results_with_department.department_id
+      FROM (
+        SELECT r.id as result_id, d.id as department_id
+        FROM results r
+        INNER JOIN direct_assessments da ON r.assessment_type = 'DirectAssessment' AND da.id = r.assessment_id
+        INNER JOIN outcome_assessments oa ON oa.assessment_type = 'DirectAssessment' AND oa.assessment_id = da.id
+        INNER JOIN outcomes o ON o.id = oa.outcome_id
+        INNER JOIN courses c ON c.id = o.course_id
+        INNER JOIN departments d ON d.id = c.department_id
+      ) as results_with_department
+      WHERE
+         results_with_department.result_id = results.id
+    SQL
+  end
+
+  def populate_results_department_for_indirect_assessments
+    execute <<-SQL
+      UPDATE results SET department_id = results_with_department.department_id
+      FROM (
+        SELECT r.id as result_id, d.id as department_id
+        FROM results r
+        INNER JOIN indirect_assessments ia ON r.assessment_type = 'IndirectAssessment' AND ia.id = r.assessment_id
+        INNER JOIN outcome_assessments oa ON oa.assessment_type = 'IndirectAssessment' AND oa.assessment_id = ia.id
+        INNER JOIN outcomes o ON o.id = oa.outcome_id
+        INNER JOIN courses c ON c.id = o.course_id
+        INNER JOIN departments d ON d.id = c.department_id
+      ) as results_with_department
+      WHERE
+         results_with_department.result_id = results.id
+    SQL
+  end
+end

--- a/db/migrate/20151223163901_index_item_type_on_versions.rb
+++ b/db/migrate/20151223163901_index_item_type_on_versions.rb
@@ -1,0 +1,5 @@
+class IndexItemTypeOnVersions < ActiveRecord::Migration
+  def change
+    add_index :versions, :item_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 20151223163901) do
     t.string   "semester"
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.integer  "department_id"
   end
 
   add_index "results", ["assessment_id", "assessment_type", "year", "semester"], name: "index_results_on_assessment_and_year_and_semester", unique: true, using: :btree
@@ -152,6 +153,7 @@ ActiveRecord::Schema.define(version: 20151223163901) do
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
+  add_index "versions", ["item_type"], name: "index_versions_on_item_type", using: :btree
 
   add_foreign_key "alignments", "outcomes"
   add_foreign_key "alignments", "standard_outcomes"

--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+feature "User views activity feed" do
+  around do |example|
+    PaperTrail.enabled = true
+    example.run
+    PaperTrail.enabled = false
+  end
+
+  scenario "sees recent results they have access to" do
+    result = create(:result)
+    result.update!(percentage: 99)
+    user = user_with_read_access_to(result.department)
+
+    visit activities_path(as: user)
+
+    expect(page).to have_content "Results created for #{result.name}"
+    expect(page).to have_content "Results updated for #{result.name}"
+  end
+end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe DateHelper do
+  describe "#relative_date" do
+    it "is 'Today' if supplied the current date" do
+      expect(helper.relative_date(Date.today)).to eq "Today"
+    end
+
+    it "is 'Yesterday if supplied yesterday's date" do
+      expect(helper.relative_date(Date.yesterday)).to eq "Yesterday"
+    end
+
+    it "is the exact date otherwise" do
+      expect(helper.relative_date(DateTime.new(2000, 01, 01, 0, 0, 0))).to match(/01-01-2000/)
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe Activity do
+  describe "#date" do
+    it "is the created_at timestamp as a date" do
+      activity = Activity.new(created_at: Time.current)
+
+      expect(activity.date).to eq Time.current.to_date
+    end
+  end
+end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Result do
+  it "denomarlizes the department from the associated assessment on save" do
+    assessment = create(:direct_assessment)
+    result = build(:result, assessment: assessment)
+
+    result.save!
+
+    expect(result.department_id).to eq assessment.department.id
+  end
+
+  describe "#name" do
+    it "combines the assessment name and description from the result" do
+      result = Result.new(
+        assessment_name: "name",
+        assessment_description: "description",
+      )
+
+      expect(result.name).to eq "name - description"
+    end
+  end
+end


### PR DESCRIPTION
Users wanted to quickly be able to see if results were being added for
the departments they have access to.

The result activity feed is built off of data that PaperTrail already
has for results. It tracks every create, update, and delete so we don't
have to. I created an `Activity` model that has some additional smarts
about what we want to get out PaperTrail data (the associated user, the
associated, non-polymorphic result).

To accommodate authorization in a performant way, I denormalized the
department a result is associated to. Previously the result department
came from `assessment -> outcomes -> courses -> departments`. Due to the
polymorphic assessment relationship, we weren't going to be able to
efficiently (read: In SQL) limit the results to only those in
departments the user can access. By caching the department at save
time, we can quickly get at this data.

One downside of this is that we can't easily show activities for deleted
results. The result is no longer in the results table, so we can't tell
what department it belongs to. We may be able to rehydrate this data
from the PaperTrail version, but doing so would be non-trivial. Earlier
Jon had mentioned that maintaing deletes was not a priority, so I went
with this for now.