### PR TITLE
Make logo crisp

### DIFF
--- a/app/assets/images/logo.svg
+++ b/app/assets/images/logo.svg
@@ -1,13 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 71.7 37.1" enable-background="new 0 0 71.7 37.1" xml:space="preserve">
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#CCCCCC" points="38.3,7.4 38.3,0 46.2,0 46.2,7.4 38.3,7.4 "/>
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#CCCCCC" points="51.1,37.1 51.1,11.8 59,11.8 59,37.1 51.1,37.1 "/>
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#CCCCCC" points="0,0 7.8,0 7.8,37.1 0,37.1 0,0 "/>
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#CCCCCC" points="25.6,37.1 25.6,0 33.4,0 33.4,37.1 25.6,37.1 "/>
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#CCCCCC" points="12.8,25.4 12.8,0 20.6,0 20.6,25.4 12.8,25.4 "/>
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#CCCCCC" points="51.1,7.4 51.1,0 71.7,0 71.7,7.4 51.1,7.4 "/>
-<polygon fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" points="38.4,37.1 38.4,11.7 46.2,11.7 46.2,37.1 38.4,37.1 "/>
+<svg width="67" height="34" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#CCC" d="M0 0h7v34H0zM12 0h7v23h-7zM24 0h7v34h-7zM36 0h7v7h-7z"/>
+  <path fill="#FFF" d="M36 11h7v23h-7z"/>
+  <path fill="#CCC" d="M48 11h7v23h-7zM48 0h19v7H48z"/>
 </svg>

--- a/app/assets/stylesheets/refills/_navigation.scss
+++ b/app/assets/stylesheets/refills/_navigation.scss
@@ -31,15 +31,13 @@ header.navigation {
   }
 
   .logo {
+    $logo-height: 34px;
+
     float: left;
     max-height: $navigation-height;
     padding-left: $navigation-padding;
     padding-right: 2em;
-
-    img {
-      height: $navigation-height;
-      padding: 0.8em 0;
-    }
+    padding-top: ($navigation-height - $logo-height) / 2;
   }
 
   .navigation-menu-button {


### PR DESCRIPTION
Not really necessary, but nice for people on high res laptops. Before and After (have to click the image to expand it and see the difference):

<img width="205" alt="screen shot 2016-01-06 at 3 10 11 pm" src="https://cloud.githubusercontent.com/assets/1214346/12153552/735f9050-b488-11e5-9f9a-69f2b5db049f.png">

