### PR TITLE
Remove utf8 parameter from filter form

### DIFF
--- a/app/views/manage_assessments/assessments/_filter_form.html.erb
+++ b/app/views/manage_assessments/assessments/_filter_form.html.erb
@@ -1,4 +1,7 @@
-<%= form_tag manage_assessments_course_assessments_path(course), method: :get do %>
+<%= form_tag manage_assessments_course_assessments_path(course),
+  method: :get,
+  enforce_utf8: false do %>
+
   <%= select_tag(
     "outcome_ids",
     options_from_collection_for_select(


### PR DESCRIPTION
This is a get request and is not necessary. It just adds cruft to the
URL which isn't a big deal but it visually displeasing, at least to me.