### PR TITLE
Update assessment creation permissions

### DIFF
--- a/app/policies/generic_policy.rb
+++ b/app/policies/generic_policy.rb
@@ -6,7 +6,10 @@ class GenericPolicy
   end
 
   def create_assessments?
-    user.manage_assessments?(AnyDepartment.new)
+    Course.joins(:department).
+      where(departments: { slug: user.department_slugs(Permission::MANAGE_ASSESSMENTS) }).
+      with_outcomes.
+      any?
   end
 
   def view_assessments?

--- a/config/dev-roles.yaml
+++ b/config/dev-roles.yaml
@@ -62,4 +62,3 @@
     is_active_now: 'Y'
     name: 'daries'
     account_has_access_to: 'D_AEROASTRO'
-

--- a/config/initializers/gradebook_client.rb
+++ b/config/initializers/gradebook_client.rb
@@ -5,7 +5,7 @@ GradebookClient.configure do |config|
       client_cert: File.read("config/certs/outcomes.cer"),
       client_key: File.read("config/certs/outcomes-key.pem"),
     )
-  elsif Rails.env.staging? || File.exists?("config/certs/outcomes-dev-cert.pem")
+  elsif Rails.env.staging? || Rails.env.development? && File.exists?("config/certs/outcomes-dev-cert.pem")
     config.adapter = GradebookClient::Adapters::LearningModules.new(
       endpoint: "https://learning-modules-dev.mit.edu:8443/service/gradebook/",
       client_cert: File.read("config/certs/outcomes-dev-cert.pem"),

--- a/spec/features/user_views_subjects_spec.rb
+++ b/spec/features/user_views_subjects_spec.rb
@@ -17,11 +17,7 @@ feature "User views list of subjects" do
     click_on "Record Data"
 
     expect(page).to have_content permitted_subject.number
-    expect(page).to have_content permitted_subject.title
-
-    expect(page).not_to have_content unpermitted_subject.number
     expect(page).not_to have_content unpermitted_subject.title
-    expect(page).not_to have_content subject_without_assessment.number
     expect(page).not_to have_content subject_without_assessment.title
   end
 end

--- a/spec/policies/generic_policy_spec.rb
+++ b/spec/policies/generic_policy_spec.rb
@@ -4,18 +4,27 @@ describe GenericPolicy do
   include PermissionsHelpers
 
   describe "#create_assessments" do
-    it "is true if the user is an admin for any department" do
-      department = instance_double(Department, slug: "Foo")
-      user = user_with_admin_access_to(department)
+    it "is true if the user manages assessments for courses with outcomes" do
+      course = create(:outcome).course
+      user = user_with_assessments_access_to(course.department)
 
       policy = GenericPolicy.new(user, nil)
 
       expect(policy.create_assessments?).to eq true
     end
 
-    it "is false otherwise" do
-      department = instance_double(Department, slug: "Foo")
-      user = user_with_read_access_to(department)
+    it "is false if the user manages assessments on courses without outcomes" do
+      department = create(:course).department
+      user = user_with_assessments_access_to(department)
+
+      policy = GenericPolicy.new(user, nil)
+
+      expect(policy.create_assessments?).to eq false
+    end
+
+    it "is false if the user is not an admin of any courses with outcomes" do
+      course = create(:outcome).course
+      user = user_with_read_access_to(course.department)
 
       policy = GenericPolicy.new(user, nil)
 


### PR DESCRIPTION
A user should only be able to create assessments if they have the proper
assessment permission **and** one of the departments they have access
to actually has outcomes they can assign assessments to.

Previously, only the permission level was checked. If the user had
permissions to add assessments to a single department they could find
themselves starting at a form they can't successfully submit because
they can't assign any outcomes to their new assessment.