### PR TITLE
Add API to get outcomes for a subject

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "2.2.2"
 
 gem "rails", "~> 5.0.0"
+gem "active_model_serializers", "~> 0.10.6"
 gem "email_validator"
 gem "flutie"
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.6)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
     activejob (5.0.2)
       activesupport (= 5.0.2)
       globalid (>= 0.3.6)
@@ -96,6 +101,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     database_cleaner (1.5.3)
@@ -135,6 +142,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jsonapi-renderer (0.1.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.19)
@@ -304,6 +312,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.6)
   autoprefixer-rails
   awesome_print
   bullet

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,5 @@
+module Api
+  class BaseController < ActionController::Base
+    protect_from_forgery with: :null_session
+  end
+end

--- a/app/controllers/api/outcomes_controller.rb
+++ b/app/controllers/api/outcomes_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  class OutcomesController < BaseController
+    def index
+      outcomes = subject.outcomes.distinct
+      render json: outcomes
+    end
+
+    private
+
+    def subject
+      Subject.find_by!(number: params[:subject_id])
+    end
+  end
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -4,6 +4,7 @@ class Subject < ActiveRecord::Base
   has_many :direct_assessments, -> {
     merge(DirectAssessment.unarchived).order(:name)
   }
+  has_many :outcomes, through: :direct_assessments
 
   def self.sorted_by_number
     order(number: :asc).sort_by { |s| s.number.to_f }

--- a/app/serializers/outcome_serializer.rb
+++ b/app/serializers/outcome_serializer.rb
@@ -1,0 +1,3 @@
+class OutcomeSerializer < ActiveModel::Serializer
+  attributes :name, :description
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,12 @@ Rails.application.routes.draw do
     resources :results, only: [:new, :create]
   end
 
+  namespace :api do
+    resources :subjects, only: [], id: /[A-Z0-9\.]+?/i do
+      resources :outcomes, only: [:index]
+    end
+  end
+
   namespace :manage_assessments do
     root "dashboard#show"
 

--- a/spec/requests/api/subject_outcomes_spec.rb
+++ b/spec/requests/api/subject_outcomes_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "subject outcomes api" do
+  it "returns a unique list of outcomes for the given subject" do
+    subject = create(:subject, number: "1.234")
+    outcome,_ = create_pair(:outcome)
+    assessment = create_pair :direct_assessment,
+      subject: subject,
+      outcomes: [outcome]
+
+    get api_subject_outcomes_path(subject.number)
+
+    expect(response).to be_ok
+    expect(parsed_response.size).to eq 1
+    expect(parsed_response.first["name"]).to eq outcome.name
+    expect(parsed_response.first["description"]).to eq outcome.description
+  end
+
+  def parsed_response
+    @parsed_response ||= JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
Faculty want to be able to display outcomes associated with a
class/subject on their own websites. This API will allow them to do
that.

The API format is extremely simplistic at this point. Jon is checking to
see if there are preferred standards (JSON API?) within use at MIT. In
the meantime, I thought this simplified format would likely be of the
most use to the people we think will be consuming this API.

Example output:

```
[
    {
        "description": "an ability to function on multidisciplinary teams",
        "name": "d"
    },
    {
        "description": "an ability to identify, formulate, and solve engineering problems",
        "name": "e"
    }
]
```