### PR TITLE
Show list of accessible reports if necessary

### DIFF
--- a/app/controllers/reports/courses_controller.rb
+++ b/app/controllers/reports/courses_controller.rb
@@ -3,7 +3,7 @@ module Reports
     def index
       @courses = policy_scope(Course)
 
-      if @courses.size >= 1
+      if @courses.size == 1
         redirect_to course_assessment_report_path(course_id: @courses.first)
       end
     end

--- a/spec/features/user_views_reports_spec.rb
+++ b/spec/features/user_views_reports_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+feature "User views reports" do
+  scenario "sees list of accessible courses if they have access to multiple" do
+    user = create(:user)
+    courses = create_pair(:course)
+    grant_access(user, courses.map(&:department), Permission::ASSESSMENTS)
+
+    visit reports_path(as: user)
+
+    expect(page).to have_content(courses.first.name)
+    expect(page).to have_content(courses.last.name)
+  end
+end


### PR DESCRIPTION
Some users have access to more than one course that has reports. In this
case, we are supposed to show them a list of accessible reports, but due
to a bug we were redirecting to their first accessible course instead.
We only want to redirect if they have access to exactly one course.