### PR TITLE
Allow All Outcomes to be selected in dropdown

### DIFF
--- a/app/assets/javascripts/selects.js
+++ b/app/assets/javascripts/selects.js
@@ -1,5 +1,7 @@
 $(function() {
-  $("select").selectize({
+  $("select[data-allow-empty-option]").selectize({
     allowEmptyOption: true,
   });
+
+  $("select").not("[data-allow-empty-option]").selectize({});
 });

--- a/app/views/manage_assessments/assessments/_filter_form.html.erb
+++ b/app/views/manage_assessments/assessments/_filter_form.html.erb
@@ -11,8 +11,8 @@
       params[:outcome_ids],
     ),
     include_blank: t(".all_outcomes"),
-    data: { behavior: "auto-submit" },
-    placeholder: "All Outcomes",
+    data: { behavior: "auto-submit", allow_empty_option: "true" },
+    placeholder: "All Outcomes"
   ) %>
 
   <%= submit_tag "Filter", data: { behavior: :hidden } %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/UczbcH1G)

Added a data attribute to html to ensure that `All Outcomes` can be selected in the dropdown list during assessment management while all other dropdowns allow the user to type directly into the selection field.

_Select All Outcomes from dropdown_
<img width="1673" alt="screen shot 2017-05-10 at 11 08 24 am" src="https://cloud.githubusercontent.com/assets/9501674/25905877/18f3f334-3571-11e7-9200-3a5864ebabb1.png">

_Type directly into selection dropdown box_
<img width="1673" alt="screen shot 2017-05-10 at 11 08 49 am" src="https://cloud.githubusercontent.com/assets/9501674/25905884/1ee252cc-3571-11e7-9b34-31bd14652f02.png">