### PR TITLE
Add a custom outcome from the view outcomes page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,9 +73,6 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.3)
-    bullet (5.5.1)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.10.0)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -294,7 +291,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    uniform_notifier (1.10.0)
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
@@ -316,7 +312,6 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.6)
   autoprefixer-rails
   awesome_print
-  bullet
   bundler-audit
   byebug
   capistrano-rails

--- a/app/views/manage_outcomes/outcomes/_outcomes.html.erb
+++ b/app/views/manage_outcomes/outcomes/_outcomes.html.erb
@@ -25,6 +25,6 @@
   </tbody>
 </table>
 
-<% if course.has_custom_outcomes? && policy(course).create_outcomes? %>
+<% if policy(course).create_outcomes? %>
   <%= link_to t(".add_outcome"), new_manage_outcomes_course_outcome_path(course), class: "button" %>
 <% end %>

--- a/spec/features/admin_views_outcomes_for_specific_course_spec.rb
+++ b/spec/features/admin_views_outcomes_for_specific_course_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+feature 'Admin views the outcomes for a specific course' do
+  scenario 'with fully aligned outcomes' do
+    course = create(:course, :fully_aligned)
+    admin = user_with_admin_access_to(course.department)
+
+    view_outcomes_of_a_specific_course_as(admin)
+
+    course_outcome_name = course.outcomes.first.name
+    course_outcome_description = course.outcomes.first.description
+
+    expect(page).to have_content('Add A Custom Outcome')
+    expect(page).to have_outcome_name(course_outcome_name)
+    expect(page).to have_outcome_description(course_outcome_description)
+    expect(page).to have_content('Edit Outcome')
+  end
+
+  scenario 'with unaligned outcomes' do
+    course = create(:course, :with_unaligned_outcome)
+    admin = user_with_admin_access_to(course.department)
+
+    view_outcomes_of_a_specific_course_as(admin)
+
+    course_outcome_name = course.outcomes.first.name
+    course_outcome_description = course.outcomes.first.description
+
+    expect(page).to have_content('Add A Custom Outcome')
+    expect(page).to have_outcome_name(course_outcome_name)
+    expect(page).to have_outcome_description(course_outcome_description)
+    expect(page).to have_content('Edit Outcome')
+  end
+
+  def have_outcome_name(name)
+    have_content(name)
+  end
+
+  def have_outcome_description(text)
+    have_content(text)
+  end
+
+  def view_outcomes_of_a_specific_course_as(user)
+    visit manage_outcomes_root_path(as: user)
+    click_on 'View Outcomes'
+  end
+end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/MCZC8vjn)

When the user clicks the "Adopt Standard Outcomes" button from the "Manage Outcomes Dashboard" and then returns to the dashboard and clicks on "View Outcomes", an "Add a Custom Outcome" button should appear regardless of whether the course has unaligned or fully aligned
outcomes.

_Prior - no button for adding a custom outcome_
<img width="844" alt="abet_outcomes_assessment" src="https://cloud.githubusercontent.com/assets/9501674/25919466/c40a817c-359c-11e7-9496-e3d7d6b3c9d0.png">

_Course that has adopted all standard outcomes can now add a custom outcome_
<img width="1072" alt="screen shot 2017-05-10 at 4 22 08 pm" src="https://cloud.githubusercontent.com/assets/9501674/25919495/df164da2-359c-11e7-854b-d22e0401a60b.png">