### PR TITLE
Add nickname field to outcomes

### DIFF
--- a/app/controllers/manage_outcomes/outcomes_controller.rb
+++ b/app/controllers/manage_outcomes/outcomes_controller.rb
@@ -75,6 +75,7 @@ class ManageOutcomes::OutcomesController < ApplicationController
     params.require(:outcome).permit(
       :name,
       :description,
+      :nickname,
       :standard_outcome_id,
       alignments_attributes: [
         :_destroy,

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -15,6 +15,7 @@ class Outcome < ActiveRecord::Base
     allow_destroy: true
 
   validates :name, presence: true, uniqueness: { scope: :course_id }
+  validates :nickname, presence: true, uniqueness: { scope: :course_id }
   validates :description, presence: true
 
   has_paper_trail

--- a/app/services/adoption.rb
+++ b/app/services/adoption.rb
@@ -12,6 +12,7 @@ class Adoption
     ActiveRecord::Base.transaction do
       adoptable_outcomes.each do |adoptable_outcome|
         outcome = course.outcomes.build(
+          nickname: adoptable_outcome.nickname,
           name: adoptable_outcome.name,
           description: adoptable_outcome.description
         )

--- a/app/views/manage_outcomes/outcomes/_form.html.erb
+++ b/app/views/manage_outcomes/outcomes/_form.html.erb
@@ -3,6 +3,7 @@
 <div class="simple-form-chunk">
   <%= f.input :name%>
   <%= f.input :description %>
+  <%= f.input :nickname %>
 </div>
 
 <fieldset class="alignments">

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -26,6 +26,8 @@ en:
         name: The name or number of the outcome. Typically these are short and
           indicative of a sequential numbering system, like '1.1, 1.2... or a,
           b, c…'
+        nickname: A short identifier to quickly recall the topics an outcome
+          covers.
       result:
         assessment_description: A brief description of the assignment, survey,
           or program.

--- a/db/migrate/20170515183207_add_nickname_to_outcomes.rb
+++ b/db/migrate/20170515183207_add_nickname_to_outcomes.rb
@@ -1,0 +1,51 @@
+class AddNicknameToOutcomes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :standard_outcomes, :nickname, :string
+    add_column :outcomes, :nickname, :string
+
+    reversible do |dir|
+      dir.up do
+        mapping = {
+          a: 'Science and Engineering',
+          b: 'Experimentation',
+          c: 'Design',
+          d: 'Teamwork',
+          e: 'Problem Solving',
+          f: 'Ethics',
+          g: 'Communication',
+          h: 'Broad Education',
+          i: 'Life-long Learning',
+          j: 'Contemporary Issues',
+          k: 'Modern Practice',
+        }
+
+        mapping.each do |name, nickname|
+          execute <<-SQL
+            UPDATE standard_outcomes
+            SET nickname = '#{nickname}'
+            WHERE name = '#{name}'
+          SQL
+        end
+
+        execute <<-SQL
+          UPDATE outcomes
+          SET nickname = standard_outcomes.nickname
+          FROM standard_outcomes
+          WHERE standard_outcomes.description = outcomes.description
+        SQL
+
+        execute <<-SQL
+          UPDATE outcomes
+          SET nickname = outcomes.name
+          WHERE nickname IS NULL
+        SQL
+      end
+    end
+
+    change_column_null :standard_outcomes, :nickname, false
+    change_column_null :outcomes, :nickname, false
+
+    add_index :standard_outcomes, :nickname, unique: true
+    add_index :outcomes, [:course_id, :nickname], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170509015537) do
+ActiveRecord::Schema.define(version: 20170515183207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,9 @@ ActiveRecord::Schema.define(version: 20170509015537) do
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.integer  "assessments_count", default: 0, null: false
+    t.string   "nickname",                      null: false
     t.index ["course_id", "name"], name: "index_outcomes_on_course_id_and_name", unique: true, using: :btree
+    t.index ["course_id", "nickname"], name: "index_outcomes_on_course_id_and_nickname", unique: true, using: :btree
   end
 
   create_table "results", force: :cascade do |t|
@@ -106,6 +108,8 @@ ActiveRecord::Schema.define(version: 20170509015537) do
     t.string   "description", null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "nickname",    null: false
+    t.index ["nickname"], name: "index_standard_outcomes_on_nickname", unique: true, using: :btree
   end
 
   create_table "subjects", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,22 +32,25 @@ ActiveRecord::Base.transaction do
   end
 
   standard_outcomes = [
-    ["a", "an ability to apply knowledge of mathematics, science, and engineering"],
-    ["b", "an ability to design and conduct experiments, as well as to analyze and interpret data"],
-    ["c", "an ability to design a system, component, or process to meet desired needs within realistic constraints such as economic, environmental, social, political, ethical, health and safety, manufacturability, and sustainability"],
-    ["d", "an ability to function on multidisciplinary teams"],
-    ["e", "an ability to identify, formulate, and solve engineering problems"],
-    ["f", "an understanding of professional and ethical responsibility"],
-    ["g", "an ability to communicate effectively"],
-    ["h", "the broad education necessary to understand the impact of engineering solutions in a global, economic, environmental, and societal context"],
-    ["i", "a recognition of the need for, and an ability to engage in life-long learning"],
-    ["j", "a knowledge of contemporary issues"],
-    ["k", "an ability to use the techniques, skills, and modern engineering tools necessary for engineering practice"]
+    ["Science and Engineering", "a", "an ability to apply knowledge of mathematics, science, and engineering"],
+    ["Experimentation", "b", "an ability to design and conduct experiments, as well as to analyze and interpret data"],
+    ["Design", "c", "an ability to design a system, component, or process to meet desired needs within realistic constraints such as economic, environmental, social, political, ethical, health and safety, manufacturability, and sustainability"],
+    ["Teamwork", "d", "an ability to function on multidisciplinary teams"],
+    ["Problem Solving", "e", "an ability to identify, formulate, and solve engineering problems"],
+    ["Ethics", "f", "an understanding of professional and ethical responsibility"],
+    ["Communication", "g", "an ability to communicate effectively"],
+    ["Broad Education", "h", "the broad education necessary to understand the impact of engineering solutions in a global, economic, environmental, and societal context"],
+    ["Life-long Learning", "i", "a recognition of the need for, and an ability to engage in life-long learning"],
+    ["Contemporary Issues", "j", "a knowledge of contemporary issues"],
+    ["Modern Practice", "k", "an ability to use the techniques, skills, and modern engineering tools necessary for engineering practice"]
   ]
 
   standard_outcomes.each do |outcome|
-    StandardOutcome.find_or_create_by(name: outcome[0],
-      description: outcome[1])
+    StandardOutcome.find_or_create_by(
+      nickname: outcome[0],
+      name: outcome[1],
+      description: outcome[2],
+    )
   end
 
   subject_csv = Rails.root.join("config", "subjects.csv")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   sequence(:label) { |n| ("a".."zzz").to_a[n - 1] }
   sequence(:name) { |n| "The #{n.ordinalize} Name" }
+  sequence(:nickname) { |n| "Nickname #{n}" }
   sequence(:description) { |n| "The #{n.ordinalize} Description" }
   sequence(:number) { |n| n.to_s }
 
@@ -71,6 +72,7 @@ FactoryGirl.define do
   end
 
   factory :outcome do
+    nickname
     name { generate(:label) }
     description { "description for custom #{name}" }
     course
@@ -85,6 +87,7 @@ FactoryGirl.define do
   end
 
   factory :standard_outcome do
+    nickname
     name { generate(:label) }
     description { "description for standard #{name}" }
   end

--- a/spec/features/admin_creates_custom_outcome_spec.rb
+++ b/spec/features/admin_creates_custom_outcome_spec.rb
@@ -11,6 +11,7 @@ feature "Admin creates custom outcomes" do
     click_link "Create Custom Outcome"
     fill_in "Name", with: "X"
     fill_in "Description", with: description
+    fill_in "Nickname", with: "Nickname"
     select Alignment::LEVELS.first, from: standard_outcome
     click_on "Create Outcome"
 


### PR DESCRIPTION
Associating a nickname to each outcome will allow us to concisely
represent outcomes in the UI in a way that the user can still understand
what the outcomes mean. The nickname must be unique to the associated
course.

We updated all existing outcomes with a nickname. Outcomes based on
standard outcomes were updated to use the canonical nicknames provided
by Jon. Custom outcomes were updated to use their name as nickname. Jon
will investigate updating these manually at a later time.

Finally, we opened a new Trello card to cover displaying the nickname
alongside the outcomes in the "Manage Outcomes" views as we weren't sure
how to best do this right now.