### PR TITLE
Refactor outcome coverages some

### DIFF
--- a/app/controllers/manage_assessments/courses_controller.rb
+++ b/app/controllers/manage_assessments/courses_controller.rb
@@ -5,4 +5,10 @@ class ManageAssessments::CoursesController < ApplicationController
   def index
     @courses = policy_scope(Course).includes(outcomes: :department)
   end
+
+  def show
+    @course = policy_scope(Course).
+      includes(outcome_coverages: [:subject, :outcome]).
+      find(params[:id])
+  end
 end

--- a/app/controllers/manage_assessments/outcome_coverages_controller.rb
+++ b/app/controllers/manage_assessments/outcome_coverages_controller.rb
@@ -10,14 +10,10 @@ module ManageAssessments
       authorize(@outcome_coverage)
 
       if @outcome_coverage.save
-        redirect_to manage_assessments_course_outcome_coverages_path
+        redirect_to manage_assessments_course_path(course)
       else
         render :new
       end
-    end
-
-    def index
-      @course = course
     end
 
     private

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -23,4 +23,8 @@ class Outcome < ActiveRecord::Base
   def to_s
     "#{name} - #{description}"
   end
+
+  def label
+    "#{name} - #{nickname}"
+  end
 end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -4,5 +4,4 @@ class OutcomeCoverage < ActiveRecord::Base
   belongs_to :subject
 
   delegate :name, :nickname, to: :outcome, prefix: true
-  delegate :title, to: :subject, prefix: true
 end

--- a/app/views/manage_assessments/courses/show.html.erb
+++ b/app/views/manage_assessments/courses/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @course.name %></h1>
+<div><%= t(".course_number", number: @course.number) %></div>
+
+<section id="matched_outcomes">
+  <%= render @course.outcome_coverages %>
+</section>
+
+<%= link_to t(".add_a_class"), new_manage_assessments_course_outcome_coverage_path(@course) %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -1,4 +1,4 @@
-<h2><%= outcome_coverage.subject_title %></h2>
+<h2><%= outcome_coverage.subject %></h2>
 
 <div>
   <p>Outcome <%= outcome_coverage.outcome_name %></p>

--- a/app/views/manage_assessments/outcome_coverages/index.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/index.html.erb
@@ -1,8 +1,0 @@
-<h1><%= @course.number %></h1>
-<h1><%= @course.name %></h1>
-
-<%= link_to t('.add_a_class'), new_manage_assessments_course_outcome_coverage_path(@course) %>
-
-<section id="matched_outcomes">
-  <%= render @course.outcome_coverages %>
-</section>

--- a/app/views/manage_assessments/outcome_coverages/new.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/new.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for @outcome_coverage, url: manage_assessments_course_outcome_coverages_path(course_id: @outcome_coverage.course.id) do |form| %>
-  <%= form.input :subject_id, collection: Subject.all %>
-  <%= form.input :outcome_id, collection: @outcome_coverage.course.outcomes, label_method: :nickname %>
+  <%= form.input :subject_id, collection: Subject.sorted_by_number, label_method: :to_s %>
+  <%= form.input :outcome_id, collection: @outcome_coverage.course.outcomes, label_method: :label %>
   <%= form.button :submit %>
 <% end %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -60,6 +60,6 @@ en:
         description: Description
         heading: Outcomes for %{name}
         label: Label
-    outcome_coverages:
-      index:
+      show:
         add_a_class: Add a class
+        course_number: Course %{number}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
   namespace :manage_assessments do
     root "dashboard#show"
 
-    resources :courses, only: [:index] do
-      resources :outcome_coverages, only: [:index, :new, :create]
+    resources :courses, only: [:index, :show] do
+      resources :outcome_coverages, only: [:new, :create]
       resources :assessments, only: [:index]
     end
 

--- a/spec/features/user_adds_outcome_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_outcome_coverage_to_a_course_spec.rb
@@ -7,8 +7,8 @@ feature "user adds outcome coverage to a course" do
     outcome = create(:outcome, course: course)
     user = user_with_assessments_access_to(course.department)
 
-    visit manage_assessments_course_outcome_coverages_path(course, as: user)
-    click_on t('manage_assessments.outcome_coverages.index.add_a_class')
+    visit manage_assessments_course_path(course, as: user)
+    click_on t('manage_assessments.courses.show.add_a_class')
     select subject.title, from: "outcome_coverage[subject_id]"
     select outcome.nickname, from: "outcome_coverage[outcome_id]"
     click_button t('helpers.submit.outcome_coverage.create')


### PR DESCRIPTION
* Moved `outcome_coverages#index` to `course#show` as it seems more
accurate that we're representing the state of the assessments for the
course than an index of coverages.
* Cleaned up the select boxes on the coverage form to have proper labels
in the correct order.
* Changed courses#show html to be more in line with what the final
designed product might use.