### PR TITLE
Rename Outcome name to label and force uppercase

### DIFF
--- a/app/controllers/manage_outcomes/outcomes_controller.rb
+++ b/app/controllers/manage_outcomes/outcomes_controller.rb
@@ -6,7 +6,7 @@ class ManageOutcomes::OutcomesController < ApplicationController
     @course = course
     @unaligned_standard_outcomes = StandardOutcome.
       unaligned_with(course).
-      order(:name)
+      order(:label)
     authorize(@course, :show?)
   end
 
@@ -73,7 +73,7 @@ class ManageOutcomes::OutcomesController < ApplicationController
 
   def outcome_params
     params.require(:outcome).permit(
-      :name,
+      :label,
       :description,
       :nickname,
       :standard_outcome_id,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,6 +1,6 @@
 class Assessment < ActiveRecord::Base
   has_many :outcome_assessments, dependent: :destroy
-  has_many :outcomes, -> { order(:name) }, through: :outcome_assessments
+  has_many :outcomes, -> { order(:label) }, through: :outcome_assessments
   has_many :courses, -> { order(:id) }, through: :outcomes
 
   belongs_to :subject

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,8 +1,8 @@
 class Course < ActiveRecord::Base
   belongs_to :department
-  has_many :outcomes, -> { order(:name) }
+  has_many :outcomes, -> { order(:label) }
   has_many :outcomes_with_metadata,
-    -> { order(:name) },
+    -> { order(:label) },
     foreign_key: :course_id,
     class_name: "OutcomeWithMetadata"
   has_many :outcome_coverages

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,4 +1,6 @@
 class Outcome < ActiveRecord::Base
+  attribute :label, Label.new
+
   belongs_to :course, counter_cache: true
 
   has_one :department, through: :course
@@ -15,7 +17,7 @@ class Outcome < ActiveRecord::Base
     allow_destroy: true
 
   validates :label, presence: true, uniqueness: { scope: :course_id },
-    length: { maximum: 500 }
+    length: { maximum: 5 }
   validates :nickname, presence: true, uniqueness: { scope: :course_id }
   validates :description, presence: true
 

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -14,17 +14,18 @@ class Outcome < ActiveRecord::Base
     reject_if: ->(attributes) { attributes[:level].blank? },
     allow_destroy: true
 
-  validates :name, presence: true, uniqueness: { scope: :course_id }
+  validates :label, presence: true, uniqueness: { scope: :course_id },
+    length: { maximum: 500 }
   validates :nickname, presence: true, uniqueness: { scope: :course_id }
   validates :description, presence: true
 
   has_paper_trail
 
   def to_s
-    "#{name} - #{description}"
+    "#{label} - #{description}"
   end
 
-  def label
-    "#{name} - #{nickname}"
+  def to_short_s
+    "#{label} - #{nickname}"
   end
 end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -3,5 +3,5 @@ class OutcomeCoverage < ActiveRecord::Base
   belongs_to :outcome
   belongs_to :subject
 
-  delegate :name, :nickname, to: :outcome, prefix: true
+  delegate :label, :nickname, to: :outcome, prefix: true
 end

--- a/app/models/standard_outcome.rb
+++ b/app/models/standard_outcome.rb
@@ -10,6 +10,6 @@ class StandardOutcome < ActiveRecord::Base
   end
 
   def to_s
-    "#{name} - #{description}"
+    "#{label} - #{description}"
   end
 end

--- a/app/models/standard_outcome.rb
+++ b/app/models/standard_outcome.rb
@@ -1,4 +1,6 @@
 class StandardOutcome < ActiveRecord::Base
+  attribute :label, Label.new
+
   has_many :alignments
 
   def self.aligned_with(course)

--- a/app/policies/standard_outcome_policy.rb
+++ b/app/policies/standard_outcome_policy.rb
@@ -1,7 +1,7 @@
 class StandardOutcomePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.all.order(:name)
+      scope.all.order(:label)
     end
   end
 end

--- a/app/serializers/outcome_serializer.rb
+++ b/app/serializers/outcome_serializer.rb
@@ -1,3 +1,3 @@
 class OutcomeSerializer < ActiveModel::Serializer
-  attributes :name, :description
+  attributes :label, :description, :nickname
 end

--- a/app/services/adoption.rb
+++ b/app/services/adoption.rb
@@ -13,7 +13,7 @@ class Adoption
       adoptable_outcomes.each do |adoptable_outcome|
         outcome = course.outcomes.build(
           nickname: adoptable_outcome.nickname,
-          name: adoptable_outcome.name,
+          label: adoptable_outcome.label,
           description: adoptable_outcome.description
         )
 

--- a/app/types/label.rb
+++ b/app/types/label.rb
@@ -1,0 +1,5 @@
+class Label < ::ActiveRecord::Type::String
+  def serialize(value)
+    value.to_s.upcase
+  end
+end

--- a/app/views/manage_assessments/assessments/_filter_form.html.erb
+++ b/app/views/manage_assessments/assessments/_filter_form.html.erb
@@ -7,7 +7,7 @@
     options_from_collection_for_select(
       outcomes,
       :id,
-      ->(outcome){ t(".outcome_label", name: outcome.name.upcase) },
+      ->(outcome){ outcome.to_short_s },
       params[:outcome_ids],
     ),
     include_blank: t(".all_outcomes"),

--- a/app/views/manage_assessments/assessments/_no_assessments.html.erb
+++ b/app/views/manage_assessments/assessments/_no_assessments.html.erb
@@ -4,7 +4,7 @@
       <%= t(".no_assessments") %>
 
       <% if @filtered_outcome.present? %>
-        <%= t(".for_outcome", name: @filtered_outcome.name.capitalize) %>
+        <%= t(".for_outcome", name: @filtered_outcome.label) %>
       <% end %>
     </td>
   </tr>

--- a/app/views/manage_assessments/assessments/index.html.erb
+++ b/app/views/manage_assessments/assessments/index.html.erb
@@ -14,7 +14,7 @@
 
 <% if @filtered_outcome.present? %>
   <section class="outcome-description">
-    <h2><%= t(".outcome", name: @filtered_outcome.name.capitalize) %></h2>
+    <h2><%= t(".outcome", name: @filtered_outcome.label) %></h2>
     <p><%= @filtered_outcome.description %></p>
   </section>
 <% end %>

--- a/app/views/manage_assessments/assessments/outcomes/_outcome.html.erb
+++ b/app/views/manage_assessments/assessments/outcomes/_outcome.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag_for(:tr, outcome) do %>
-  <td><%= outcome.name%></td>
+  <td><%= outcome.label%></td>
   <td><%= outcome.description%></td>
   <td class="actions">
     <% if policy(outcome).create_assessments? %>

--- a/app/views/manage_assessments/courses/index.html.erb
+++ b/app/views/manage_assessments/courses/index.html.erb
@@ -14,7 +14,7 @@
       <tbody>
         <% course.outcomes.each do |outcome| %>
           <%= content_tag_for(:tr, outcome) do %>
-            <td><%= outcome.name%></td>
+            <td><%= outcome.label%></td>
             <td><%= outcome.description%></td>
             <td class="actions">
               <% if policy(outcome).create_assessments? %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -1,6 +1,6 @@
 <h2><%= outcome_coverage.subject %></h2>
 
 <div>
-  <p>Outcome <%= outcome_coverage.outcome_name %></p>
+  <p>Outcome <%= outcome_coverage.outcome_label %></p>
   <p><%= outcome_coverage.outcome_nickname %></p>
 </div>

--- a/app/views/manage_assessments/outcome_coverages/new.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/new.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for @outcome_coverage, url: manage_assessments_course_outcome_coverages_path(course_id: @outcome_coverage.course.id) do |form| %>
   <%= form.input :subject_id, collection: Subject.sorted_by_number, label_method: :to_s %>
-  <%= form.input :outcome_id, collection: @outcome_coverage.course.outcomes, label_method: :label %>
+  <%= form.input :outcome_id, collection: @outcome_coverage.course.outcomes, label_method: :to_short_s %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/manage_outcomes/outcomes/_alignment_fields.html.erb
+++ b/app/views/manage_outcomes/outcomes/_alignment_fields.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="alignment" data-order="<%= f.object.standard_outcome.name %>">
+<fieldset class="alignment" data-order="<%= f.object.standard_outcome.label %>">
   <%= f.input :standard_outcome_id, as: :hidden %>
   <%= f.label :level, f.object.standard_outcome.to_s, class: "outcome" %>
 

--- a/app/views/manage_outcomes/outcomes/_form.html.erb
+++ b/app/views/manage_outcomes/outcomes/_form.html.erb
@@ -1,7 +1,7 @@
 <%= render_errors(f) %>
 
 <div class="simple-form-chunk">
-  <%= f.input :name%>
+  <%= f.input :label %>
   <%= f.input :description %>
   <%= f.input :nickname %>
 </div>

--- a/app/views/manage_results/_outcomes.html.erb
+++ b/app/views/manage_results/_outcomes.html.erb
@@ -8,9 +8,9 @@
   </thead>
 
   <tbody>
-    <% outcomes.order(:name).each do |outcome| %>
+    <% outcomes.order(:label).each do |outcome| %>
       <tr>
-        <td><%= outcome.name %></td>
+        <td><%= outcome.label %></td>
         <td><%= outcome.course %></td>
         <td><%= link_to_if policy(outcome.course).show?,
               t(".view_all"),

--- a/app/views/reports/assessment_reports/show.html.erb
+++ b/app/views/reports/assessment_reports/show.html.erb
@@ -10,7 +10,7 @@
 <table>
   <thead>
     <tr>
-      <th><%= t(".outcome_name") %></th>
+      <th><%= t(".outcome_label") %></th>
       <th><%= t(".assessment_name") %></th>
       <th><%= t(".assessment_description") %></th>
       <th><%= t(".minimum_requirement") %></th>
@@ -22,7 +22,7 @@
   <tbody>
     <% @reports.each do |result| %>
       <tr>
-        <td><%= result.outcome_name %></td>
+        <td><%= result.outcome_label %></td>
         <td><%= result.assessment_name %></td>
         <td><%= result.assessment_description %></td>
         <td><%= result.minimum_requirement %></td>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -25,7 +25,6 @@ en:
         heading: Edit Assessment
       filter_form:
         all_outcomes: All Outcomes
-        outcome_label: Outcome %{name}
       index:
         assessments: Assessments (%{count})
         outcome: Outcome %{name}

--- a/config/locales/reports.en.yml
+++ b/config/locales/reports.en.yml
@@ -10,7 +10,7 @@ en:
         assessment_description: Assessment Description
         heading: "Assessment Report for %{course}"
         minimum_requirement: Minimum Requirement
-        outcome_name: Outcome Name
+        outcome_label: Outcome Label
         period: Period
         target_percentage: Target Percentage
     courses:

--- a/db/migrate/20170516194700_rename_outcomes_name.rb
+++ b/db/migrate/20170516194700_rename_outcomes_name.rb
@@ -1,0 +1,35 @@
+class RenameOutcomesName < ActiveRecord::Migration[5.0]
+  def up
+    drop_view :outcomes_with_metadata
+    drop_view :assessment_reports
+
+    rename_column :standard_outcomes, :name, :label
+    rename_column :outcomes, :name, :label
+
+    change_column :standard_outcomes, :label, :string, limit: 5
+    change_column :outcomes, :label, :string, limit: 5
+
+    execute "UPDATE outcomes SET label = UPPER(label)"
+    execute "UPDATE standard_outcomes SET label = UPPER(label)"
+
+    create_view :outcomes_with_metadata, version: 3
+    create_view :assessment_reports, version: 3
+  end
+
+  def down
+    drop_view :outcomes_with_metadata
+    drop_view :assessment_reports
+
+    rename_column :standard_outcomes, :label, :name
+    rename_column :outcomes, :label, :name
+
+    change_column :standard_outcomes, :label, :string, limit: nil
+    change_column :outcomes, :label, :string, limit: nil
+
+    execute "UPDATE outcomes SET label = LOWER(label)"
+    execute "UPDATE standard_outcomes SET label = LOWER(label)"
+
+    create_view :outcomes_with_metadata, version: 3
+    create_view :assessment_reports, version: 2
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,23 +32,23 @@ ActiveRecord::Base.transaction do
   end
 
   standard_outcomes = [
-    ["Science and Engineering", "a", "an ability to apply knowledge of mathematics, science, and engineering"],
-    ["Experimentation", "b", "an ability to design and conduct experiments, as well as to analyze and interpret data"],
-    ["Design", "c", "an ability to design a system, component, or process to meet desired needs within realistic constraints such as economic, environmental, social, political, ethical, health and safety, manufacturability, and sustainability"],
-    ["Teamwork", "d", "an ability to function on multidisciplinary teams"],
-    ["Problem Solving", "e", "an ability to identify, formulate, and solve engineering problems"],
-    ["Ethics", "f", "an understanding of professional and ethical responsibility"],
-    ["Communication", "g", "an ability to communicate effectively"],
-    ["Broad Education", "h", "the broad education necessary to understand the impact of engineering solutions in a global, economic, environmental, and societal context"],
-    ["Life-long Learning", "i", "a recognition of the need for, and an ability to engage in life-long learning"],
-    ["Contemporary Issues", "j", "a knowledge of contemporary issues"],
-    ["Modern Practice", "k", "an ability to use the techniques, skills, and modern engineering tools necessary for engineering practice"]
+    ["Science and Engineering", "A", "an ability to apply knowledge of mathematics, science, and engineering"],
+    ["Experimentation", "B", "an ability to design and conduct experiments, as well as to analyze and interpret data"],
+    ["Design", "C", "an ability to design a system, component, or process to meet desired needs within realistic constraints such as economic, environmental, social, political, ethical, health and safety, manufacturability, and sustainability"],
+    ["Teamwork", "D", "an ability to function on multidisciplinary teams"],
+    ["Problem Solving", "E", "an ability to identify, formulate, and solve engineering problems"],
+    ["Ethics", "F", "an understanding of professional and ethical responsibility"],
+    ["Communication", "G", "an ability to communicate effectively"],
+    ["Broad Education", "H", "the broad education necessary to understand the impact of engineering solutions in a global, economic, environmental, and societal context"],
+    ["Life-long Learning", "I", "a recognition of the need for, and an ability to engage in life-long learning"],
+    ["Contemporary Issues", "J", "a knowledge of contemporary issues"],
+    ["Modern Practice", "K", "an ability to use the techniques, skills, and modern engineering tools necessary for engineering practice"]
   ]
 
   standard_outcomes.each do |outcome|
     StandardOutcome.find_or_create_by(
       nickname: outcome[0],
-      name: outcome[1],
+      label: outcome[1],
       description: outcome[2],
     )
   end

--- a/db/views/assessment_reports_v03.sql
+++ b/db/views/assessment_reports_v03.sql
@@ -1,0 +1,23 @@
+SELECT
+  outcomes.course_id,
+  outcomes.label as outcome_label,
+  outcomes.description as outcome_description,
+  assessments.id as assessment_id,
+  assessments.name as assessment_name,
+  assessments.description as assessment_description,
+  assessments.minimum_requirement,
+  assessments.target_percentage,
+  results.percentage as actual_percentage,
+  results.year,
+  results.semester,
+  subjects.number as subject_number,
+  subjects.title as subject_title
+FROM results
+  JOIN assessments on assessments.id = results.assessment_id
+  JOIN subjects on subjects.id = assessments.subject_id
+  JOIN outcome_assessments on outcome_assessments.assessment_id = assessments.id
+  JOIN outcomes on outcomes.id = outcome_assessments.outcome_id
+ORDER BY
+  outcomes.label asc,
+  results.year desc,
+  results.semester desc

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  sequence(:label) { |n| ("a".."zzz").to_a[n - 1] }
+  sequence(:label) { |n| ("A".."ZZZ").to_a[n - 1] }
   sequence(:name) { |n| "The #{n.ordinalize} Name" }
   sequence(:nickname) { |n| "Nickname #{n}" }
   sequence(:description) { |n| "The #{n.ordinalize} Description" }
@@ -73,8 +73,8 @@ FactoryGirl.define do
 
   factory :outcome do
     nickname
-    name { generate(:label) }
-    description { "description for custom #{name}" }
+    label
+    description { "description for custom #{label}" }
     course
   end
 
@@ -88,8 +88,8 @@ FactoryGirl.define do
 
   factory :standard_outcome do
     nickname
-    name { generate(:label) }
-    description { "description for standard #{name}" }
+    label
+    description { "description for standard #{label}" }
   end
 
   factory :subject do

--- a/spec/features/admin_creates_custom_outcome_spec.rb
+++ b/spec/features/admin_creates_custom_outcome_spec.rb
@@ -9,7 +9,7 @@ feature "Admin creates custom outcomes" do
 
     visit manage_outcomes_root_path(as: user)
     click_link "Create Custom Outcome"
-    fill_in "Name", with: "X"
+    fill_in "Label", with: "X"
     fill_in "Description", with: description
     fill_in "Nickname", with: "Nickname"
     select Alignment::LEVELS.first, from: standard_outcome

--- a/spec/features/admin_views_outcomes_for_specific_course_spec.rb
+++ b/spec/features/admin_views_outcomes_for_specific_course_spec.rb
@@ -7,11 +7,11 @@ feature "Admin views the outcomes for a specific course" do
 
     view_outcomes_of_a_specific_course_as(admin)
 
-    course_outcome_name = course.outcomes.first.name
+    course_outcome_label = course.outcomes.first.label
     course_outcome_description = course.outcomes.first.description
 
     expect(page).to have_content t("manage_outcomes.outcomes.outcomes.add_outcome")
-    expect(page).to have_outcome_name(course_outcome_name)
+    expect(page).to have_outcome_label(course_outcome_label)
     expect(page).to have_outcome_description(course_outcome_description)
     expect(page).to have_content t("manage_outcomes.outcomes.outcomes.edit_outcome")
   end
@@ -22,17 +22,17 @@ feature "Admin views the outcomes for a specific course" do
 
     view_outcomes_of_a_specific_course_as(admin)
 
-    course_outcome_name = course.outcomes.first.name
+    course_outcome_label = course.outcomes.first.label
     course_outcome_description = course.outcomes.first.description
 
     expect(page).to have_content t("manage_outcomes.outcomes.outcomes.add_outcome")
-    expect(page).to have_outcome_name(course_outcome_name)
+    expect(page).to have_outcome_label(course_outcome_label)
     expect(page).to have_outcome_description(course_outcome_description)
     expect(page).to have_content t("manage_outcomes.outcomes.outcomes.edit_outcome")
   end
 
-  def have_outcome_name(name)
-    have_content(name)
+  def have_outcome_label(label)
+    have_content(label)
   end
 
   def have_outcome_description(text)

--- a/spec/features/user_filters_course_assessments_spec.rb
+++ b/spec/features/user_filters_course_assessments_spec.rb
@@ -9,13 +9,13 @@ describe "User filters course assessments" do
 
     visit manage_assessments_course_assessments_path(course, as: user)
 
-    select "Outcome #{outcomes.first.name.upcase}", from: "outcome_ids"
+    select outcomes.first.nickname, from: "outcome_ids"
     click_button "Filter"
 
     expect(page).to have_content assessments.first.to_s
     expect(page).not_to have_content assessments.last.to_s
 
-    select "Outcome #{outcomes.last.name.upcase}", from: "outcome_ids"
+    select outcomes.last.nickname, from: "outcome_ids"
     click_button "Filter"
 
     expect(page).not_to have_content assessments.first.to_s

--- a/spec/requests/api/subject_outcomes_spec.rb
+++ b/spec/requests/api/subject_outcomes_spec.rb
@@ -12,8 +12,9 @@ describe "subject outcomes api" do
 
     expect(response).to be_ok
     expect(parsed_response.size).to eq 1
-    expect(parsed_response.first["name"]).to eq outcome.name
+    expect(parsed_response.first["label"]).to eq outcome.label
     expect(parsed_response.first["description"]).to eq outcome.description
+    expect(parsed_response.first["nickname"]).to eq outcome.nickname
   end
 
   def parsed_response


### PR DESCRIPTION
This is less ambiguous than `name`. This change also upcases all stored
labels and sets the max length of a label to 5 characters.

The type coerces any label values to uppercase both in queries and in
inserts. For example, `StandardOutcome.where(label: 'a')` will search
for standard outcomes with a label of `A`. `Outcome.create(label: 'z')` will
similarly create an outcome with a label of `Z`.

This allows us to normalize the case at the app level.