### PR TITLE
Validate outcome and subject on outcome coverage

### DIFF
--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -1,7 +1,10 @@
 class OutcomeCoverage < ActiveRecord::Base
   belongs_to :course
-  belongs_to :outcome
-  belongs_to :subject
+  belongs_to :outcome, required: true
+  belongs_to :subject, required: true
+
+  validates :outcome_id, presence: true
+  validates :subject_id, presence: true
 
   delegate :label, :nickname, to: :outcome, prefix: true
 end

--- a/db/migrate/20170517143127_add_null_false_to_outcome_coverage_associations.rb
+++ b/db/migrate/20170517143127_add_null_false_to_outcome_coverage_associations.rb
@@ -1,0 +1,7 @@
+class AddNullFalseToOutcomeCoverageAssociations < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :outcome_coverages, :course_id, false
+    change_column_null :outcome_coverages, :outcome_id, false
+    change_column_null :outcome_coverages, :subject_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170516194700) do
+ActiveRecord::Schema.define(version: 20170517143127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,9 +80,9 @@ ActiveRecord::Schema.define(version: 20170516194700) do
   create_table "outcome_coverages", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer  "course_id"
-    t.integer  "subject_id"
-    t.integer  "outcome_id"
+    t.integer  "course_id",  null: false
+    t.integer  "subject_id", null: false
+    t.integer  "outcome_id", null: false
     t.index ["course_id"], name: "index_outcome_coverages_on_course_id", using: :btree
     t.index ["outcome_id"], name: "index_outcome_coverages_on_outcome_id", using: :btree
     t.index ["subject_id"], name: "index_outcome_coverages_on_subject_id", using: :btree


### PR DESCRIPTION
Users could previously create a coverage without any of the required
association. This updates the data model to require the associations and
then updates the model to add appropriate user-facing validations.

Validations were not added to the `course` association because it is not
user-facing. If we somehow attempt to create a coverage without a
course, this is a programming error and should result in an application
error.