### PR TITLE
Enable multiple outcomes per coverage

### DIFF
--- a/app/controllers/manage_assessments/courses_controller.rb
+++ b/app/controllers/manage_assessments/courses_controller.rb
@@ -8,7 +8,7 @@ class ManageAssessments::CoursesController < ApplicationController
 
   def show
     @course = policy_scope(Course).
-      includes(coverages: [:subject, :outcome]).
+      includes(coverages: [:subject, :outcomes]).
       find(params[:id])
   end
 end

--- a/app/controllers/manage_assessments/coverages_controller.rb
+++ b/app/controllers/manage_assessments/coverages_controller.rb
@@ -2,11 +2,12 @@ module ManageAssessments
   class CoveragesController < ApplicationController
     def new
       @coverage = course.coverages.build
+      @coverage.outcome_coverages.build
       authorize(@coverage)
     end
 
     def create
-      @coverage = course.coverages.build(coverages_params)
+      @coverage = course.coverages.build(coverage_params)
       authorize(@coverage)
 
       if @coverage.save
@@ -22,8 +23,10 @@ module ManageAssessments
       @_course ||= policy_scope(Course).find(params[:course_id])
     end
 
-    def coverages_params
-      params.require(:coverage).permit(:subject_id, :outcome_id)
+    def coverage_params
+      params.
+        require(:coverage).
+        permit(:subject_id, outcome_coverages_attributes: [:coverage_id, :outcome_id])
     end
   end
 end

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -1,10 +1,28 @@
 class Coverage < ActiveRecord::Base
   belongs_to :course
-  belongs_to :outcome, required: true
   belongs_to :subject, required: true
 
-  validates :outcome_id, presence: true
-  validates :subject_id, presence: true
+  has_many :outcome_coverages
+  has_many :outcomes, through: :outcome_coverages
 
-  delegate :label, :nickname, to: :outcome, prefix: true
+  accepts_nested_attributes_for :outcome_coverages,
+    allow_destroy: true,
+    reject_if: :all_blank
+
+  validates :subject_id, presence: true
+  validate :must_have_outcomes
+
+  private
+
+  def must_have_outcomes
+    if outcome_coverages.empty? || all_outcome_coverages_marked_for_destruction?
+      errors.add(:base, :outcomes_required)
+    end
+  end
+
+  def all_outcome_coverages_marked_for_destruction?
+    outcome_coverages.all? do |outcome_coverage|
+      outcome_coverage.marked_for_destruction?
+    end
+  end
 end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -1,0 +1,6 @@
+class OutcomeCoverage < ActiveRecord::Base
+  belongs_to :coverage
+  belongs_to :outcome, required: true
+
+  delegate :label, :nickname, to: :outcome, prefix: true
+end

--- a/app/views/manage_assessments/coverages/_coverage.html.erb
+++ b/app/views/manage_assessments/coverages/_coverage.html.erb
@@ -1,6 +1,5 @@
 <h2><%= coverage.subject %></h2>
 
 <div>
-  <p><%= t(".outcome", label: coverage.outcome_label) %></p>
-  <p><%= coverage.outcome_nickname %></p>
+  <%= render coverage.outcome_coverages %>
 </div>

--- a/app/views/manage_assessments/coverages/new.html.erb
+++ b/app/views/manage_assessments/coverages/new.html.erb
@@ -1,5 +1,14 @@
 <%= simple_form_for @coverage, url: manage_assessments_course_coverages_path(course_id: @coverage.course.id) do |form| %>
-  <%= form.input :subject_id, collection: Subject.sorted_by_number, label_method: :to_s %>
-  <%= form.input :outcome_id, collection: @coverage.course.outcomes, label_method: :to_short_s %>
+  <%= form.input :subject_id,
+    collection: Subject.sorted_by_number,
+    label_method: :to_s %>
+
+  <%= form.simple_fields_for :outcome_coverages do |fields| %>
+    <%= fields.input :outcome_id,
+      collection: @coverage.course.outcomes,
+      label_method: :to_short_s,
+      required: fields.options[:child_index] == 0 %>
+  <% end %>
+
   <%= form.button :submit %>
 <% end %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -1,0 +1,2 @@
+<p><%= t(".outcome", label: outcome_coverage.outcome_label) %></p>
+<p><%= outcome_coverage.outcome_nickname %></p>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -39,8 +39,8 @@ en:
           details: Details
       update:
         success: Assessment updated successfully.
-    coverages:
-      coverage:
+    outcome_coverages:
+      outcome_coverage:
         outcome: Outcome %{label}
     dashboard:
       show:

--- a/db/migrate/20170517153248_recreate_outcome_coverages.rb
+++ b/db/migrate/20170517153248_recreate_outcome_coverages.rb
@@ -1,0 +1,32 @@
+class RecreateOutcomeCoverages < ActiveRecord::Migration[5.0]
+  def up
+    create_table :outcome_coverages do |t|
+      t.timestamps null: false
+      t.references :coverage, null: false, index: true, foreign_key: { on_delete: :cascade }
+      t.references :outcome, null: false, index: true, foreign_key: true
+
+      t.index [:coverage_id, :outcome_id], unique: true
+    end
+
+    execute <<-SQL
+      INSERT INTO outcome_coverages (coverage_id, outcome_id, created_at, updated_at)
+      SELECT id, outcome_id, now(), now() FROM coverages
+    SQL
+
+    remove_column :coverages, :outcome_id
+  end
+
+  def down
+    add_reference :coverages, :outcome, index: true, foreign_key: true
+
+    execute <<-SQL
+      UPDATE coverages
+      SET outcome_id = outcome_coverages.outcome_id
+      FROM outcome_coverages
+      WHERE outcome_coverages.coverage_id = coverages.id
+    SQL
+
+    change_column_null :coverages, :outcome_id, false
+    drop_table :outcome_coverages
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517150230) do
+ActiveRecord::Schema.define(version: 20170517153248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,9 +63,7 @@ ActiveRecord::Schema.define(version: 20170517150230) do
     t.datetime "updated_at", null: false
     t.integer  "course_id",  null: false
     t.integer  "subject_id", null: false
-    t.integer  "outcome_id", null: false
     t.index ["course_id"], name: "index_coverages_on_course_id", using: :btree
-    t.index ["outcome_id"], name: "index_coverages_on_outcome_id", using: :btree
     t.index ["subject_id"], name: "index_coverages_on_subject_id", using: :btree
   end
 
@@ -86,6 +84,16 @@ ActiveRecord::Schema.define(version: 20170517150230) do
     t.datetime "updated_at",    null: false
     t.index ["assessment_id"], name: "index_outcome_assessments_on_assessment_id", using: :btree
     t.index ["outcome_id"], name: "index_outcome_assessments_on_outcome_id", using: :btree
+  end
+
+  create_table "outcome_coverages", force: :cascade do |t|
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.integer  "coverage_id", null: false
+    t.integer  "outcome_id",  null: false
+    t.index ["coverage_id", "outcome_id"], name: "index_outcome_coverages_on_coverage_id_and_outcome_id", unique: true, using: :btree
+    t.index ["coverage_id"], name: "index_outcome_coverages_on_coverage_id", using: :btree
+    t.index ["outcome_id"], name: "index_outcome_coverages_on_outcome_id", using: :btree
   end
 
   create_table "outcomes", force: :cascade do |t|
@@ -153,9 +161,10 @@ ActiveRecord::Schema.define(version: 20170517150230) do
   add_foreign_key "assessments", "subjects"
   add_foreign_key "courses", "departments", on_delete: :restrict
   add_foreign_key "coverages", "courses"
-  add_foreign_key "coverages", "outcomes"
   add_foreign_key "coverages", "subjects"
   add_foreign_key "outcome_assessments", "assessments"
+  add_foreign_key "outcome_coverages", "coverages", on_delete: :cascade
+  add_foreign_key "outcome_coverages", "outcomes"
   add_foreign_key "outcomes", "courses"
   add_foreign_key "results", "assessments"
 

--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -9,8 +9,8 @@ feature "user adds coverage to a course" do
 
     visit manage_assessments_course_path(course, as: user)
     click_on t('manage_assessments.courses.show.add_a_class')
-    select subject.title, from: "coverage[subject_id]"
-    select outcome.nickname, from: "coverage[outcome_id]"
+    select subject.title, from: "Subject"
+    select outcome.nickname, from: "Outcome"
     click_button t('helpers.submit.coverage.create')
 
     within("#matched_outcomes") do


### PR DESCRIPTION
This allows a given class to say that it covers multiple outcomes. We do
this by adding an `OutcomeCoverage` association to `Coverage`, removing
the previously existing `belongs_to :outcome` there.

In this change, I updated the controllers, models, and tests to allow
for the possibility of multiple outcomes, but the UI does not yet expose
the ability to add a second outcome. That will come in a future change.