### PR TITLE
Add JavaScript testing of coverage creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ end
 
 group :test do
   gem "capybara"
+  gem "capybara-selenium"
   gem "database_cleaner"
   gem "launchy"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,8 +98,13 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
     case_transform (0.2)
       activesupport
+    childprocess (0.7.0)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     database_cleaner (1.5.3)
@@ -235,6 +240,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubyzip (1.2.1)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -254,6 +260,10 @@ GEM
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
     selectize-rails (0.11.2)
+    selenium-webdriver (3.4.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     simple_form (3.4.0)
@@ -299,6 +309,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -317,6 +328,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rvm
   capybara
+  capybara-selenium
   database_cleaner
   email_validator
   factory_girl_rails

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ After setting up, you can run the application using rails server:
 
     % rails server
 
+To run the tests, you will need to have Chrome and chromedriver installed. On OS
+X, you can install chromedriver with:
+
+    % brew install chromedriver
+
 ## Deployment
 
 Deployment uses Capistrano and requires a couple pre-requisites. First, add the

--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "user adds coverage to a course" do
-  scenario "successfully" do
+  scenario "successfully", js: true do
     subject = create(:subject)
     course = create(:course)
     outcome = create(:outcome, course: course)
@@ -9,13 +9,19 @@ feature "user adds coverage to a course" do
 
     visit manage_assessments_course_path(course, as: user)
     click_on t('manage_assessments.courses.show.add_a_class')
-    select subject.title, from: "Subject"
-    select outcome.nickname, from: "Outcome"
+    selectize subject.title, from: "Subject"
+    selectize outcome.nickname, from: "Outcome"
     click_button t('helpers.submit.coverage.create')
 
     within("#matched_outcomes") do
       expect(page).to have_content(subject.title)
       expect(page).to have_content(outcome.nickname)
     end
+  end
+
+  def selectize(item, from:)
+    container = find_field(from, visible: false).first(:xpath, ".//..")
+    container.find(".selectize-control").click
+    container.find("div.option", text: item).click
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,7 @@ Dir[Rails.root.join("spec/support/*.rb")].sort.each { |file| require file }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.include FactoryGirl::Syntax::Methods

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.javascript_driver = :chrome

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
We will be adding some JavaScript to this page in order to support
adding many outcomes to a coverage dynamically. To get adequate test
coverage on this, we need to have a JavaScript test driver.

We usually use capybara-webkit for this, but QT was giving me troubles
and the world seems to be moving on to chromedriver. I decided to give
chromedriver a try here. Installation was an absolute picnic compared to
QT and capybara-webkit.

With the test case now running in a JavaScript driver, we can no longer
faithfully interact with the select boxes, which are actually hidden by
Selectize. I updated the test to interact with the Selectize input
instead.