### PR TITLE
Allow multiple outcomes per coverage in the UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.2.2"
 
 gem "rails", "~> 5.0.0"
 gem "active_model_serializers", "~> 0.10.6"
+gem "cocoon"
 gem "email_validator"
 gem "flutie"
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       activesupport
     childprocess (0.7.0)
       ffi (~> 1.0, >= 1.0.11)
+    cocoon (1.2.10)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     database_cleaner (1.5.3)
@@ -329,6 +330,7 @@ DEPENDENCIES
   capistrano-rvm
   capybara
   capybara-selenium
+  cocoon
   database_cleaner
   email_validator
   factory_girl_rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,4 +3,5 @@
 //= require selectize
 //= require highcharts
 //= require highcharts/modules/data
+//= require cocoon
 //= require_tree .

--- a/app/assets/javascripts/coverages.js
+++ b/app/assets/javascripts/coverages.js
@@ -1,0 +1,5 @@
+$(function() {
+  $(document).on('cocoon:before-insert', function(e, insertedItem) {
+    $(insertedItem).find("select").selectize();
+  });
+});

--- a/app/views/manage_assessments/coverages/_outcome_coverage_fields.html.erb
+++ b/app/views/manage_assessments/coverages/_outcome_coverage_fields.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :outcome_id,
+  collection: outcomes,
+  label_method: :to_short_s,
+  required: false %>

--- a/app/views/manage_assessments/coverages/new.html.erb
+++ b/app/views/manage_assessments/coverages/new.html.erb
@@ -23,5 +23,12 @@
       required: fields.options[:child_index] == 0 %>
   <% end %>
 
+  <div class="nested-form-actions">
+    <%= link_to_add_association t('.add_outcome'),
+      form,
+      :outcome_coverages,
+      render_options: { locals: { outcomes: @coverage.course.outcomes } } %>
+  </div>
+
   <%= form.button :submit %>
 <% end %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -39,6 +39,9 @@ en:
           details: Details
       update:
         success: Assessment updated successfully.
+    coverages:
+      new:
+        add_outcome: Add an Outcome
     outcome_coverages:
       outcome_coverage:
         outcome: Outcome %{label}

--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -4,18 +4,21 @@ feature "user adds coverage to a course" do
   scenario "successfully", js: true do
     subject = create(:subject)
     course = create(:course)
-    outcome = create(:outcome, course: course)
+    first_outcome, second_outcome = create_pair(:outcome, course: course)
     user = user_with_assessments_access_to(course.department)
 
     visit manage_assessments_course_path(course, as: user)
     click_on t('manage_assessments.courses.show.add_a_class')
     selectize subject.title, from: "Subject"
-    selectize outcome.nickname, from: "Outcome"
+    selectize first_outcome.nickname, from: "Outcome"
+    click_on t('manage_assessments.coverages.new.add_outcome')
+    selectize second_outcome.nickname, from: "Outcome"
     click_button t('helpers.submit.coverage.create')
 
     within("#matched_outcomes") do
       expect(page).to have_content(subject.title)
-      expect(page).to have_content(outcome.nickname)
+      expect(page).to have_content(first_outcome.nickname)
+      expect(page).to have_content(second_outcome.nickname)
     end
   end
 


### PR DESCRIPTION
Users can now add multiple outcomes to a new coverage in the UI. This
relies on previous work done to support this in the data model. This
isn't final UI or UX, but the functionality is at least now present.

![multi-outcome](https://cloud.githubusercontent.com/assets/152152/26215742/86c88564-3bcf-11e7-8379-614a898560c6.gif)
