### PR TITLE
Add assignment to outcome coverage

### DIFF
--- a/app/controllers/manage_assessments/assignments_controller.rb
+++ b/app/controllers/manage_assessments/assignments_controller.rb
@@ -1,0 +1,28 @@
+class ManageAssessments::AssignmentsController < ApplicationController
+  def new
+    @assignment = outcome_coverage.build_assignment
+    authorize(@assignment)
+  end
+
+  def create
+    @assignment = outcome_coverage.build_assignment(assignment_params)
+    authorize(@assignment)
+
+    if @assignment.save
+      redirect_to manage_assessments_course_path(outcome_coverage.coverage.course),
+        success: t(".success", label: outcome_coverage.outcome.label)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def outcome_coverage
+    @_outcome_coverage ||= OutcomeCoverage.find(params[:outcome_coverage_id])
+  end
+
+  def assignment_params
+    params.require(:assignment).permit(:name, :problem)
+  end
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,0 +1,6 @@
+class Assignment < ActiveRecord::Base
+  belongs_to :outcome_coverage
+
+  has_one :outcome, through: :outcome_coverage
+  delegate :department, to: :outcome
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -3,4 +3,6 @@ class Assignment < ActiveRecord::Base
 
   has_one :outcome, through: :outcome_coverage
   delegate :department, to: :outcome
+
+  validates :name, presence: true
 end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -2,5 +2,7 @@ class OutcomeCoverage < ActiveRecord::Base
   belongs_to :coverage
   belongs_to :outcome, required: true
 
+  has_one :assignment
+
   delegate :label, :nickname, to: :outcome, prefix: true
 end

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -1,0 +1,9 @@
+class AssignmentPolicy < ApplicationPolicy
+  def new?
+    GenericPolicy.new(user, record).create_assessments?
+  end
+
+  def create?
+    user.manage_assessments?(record.department)
+  end
+end

--- a/app/views/manage_assessments/assignments/new.html.erb
+++ b/app/views/manage_assessments/assignments/new.html.erb
@@ -1,0 +1,5 @@
+<%= simple_form_for @assignment, url: manage_assessments_outcome_coverage_assignments_path do |form| %>
+  <%= form.input :name, label: t(".assignment") %>
+  <%= form.input :problem, label: t(".problem") %>
+  <%= form.submit t(".add") %>
+<% end %>

--- a/app/views/manage_assessments/courses/index.html.erb
+++ b/app/views/manage_assessments/courses/index.html.erb
@@ -18,7 +18,7 @@
             <td><%= outcome.description%></td>
             <td class="actions">
               <% if policy(outcome).create_assessments? %>
-                <%= link_to t(".assess"), new_manage_assessments_outcome_assessment_path(outcome) %>
+                <%= link_to t(".assess"), new_manage_assessments_outcome_coverage_assignment_path(outcome) %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -4,3 +4,10 @@
 <p class="class-card-outcome class-card-outcome-nickname">
   <%= outcome_coverage.outcome_nickname %>
 </p>
+<% if outcome_coverage.assignment.present? %>
+  <p> In <%= outcome_coverage.assignment.name %> on <%= outcome_coverage.assignment.problem %>
+<% else %>
+  <p class="class-card-outcome">
+    <%= link_to t(".add_assignment"), new_manage_assessments_outcome_coverage_assignment_path(outcome_coverage) %>
+  </p>
+<% end %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -5,7 +5,11 @@
   <%= outcome_coverage.outcome_nickname %>
 </p>
 <% if outcome_coverage.assignment.present? %>
-  <p> In <%= outcome_coverage.assignment.name %> on <%= outcome_coverage.assignment.problem %>
+  <p>
+    <%= t(".assignment_name", name: outcome_coverage.assignment.name) %>
+    <%= t(".assignment_problem",
+        problem: outcome_coverage.assignment.problem) if outcome_coverage.assignment.problem.present? %>
+  </p>
 <% else %>
   <p class="class-card-outcome">
     <%= link_to t(".add_assignment"), new_manage_assessments_outcome_coverage_assignment_path(outcome_coverage) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,11 @@ en:
               taken: results have already been recorded for this period
             percentage:
               inclusion: must be between 0 and 100
+        coverage:
+          attributes:
+            base:
+              outcomes_required: Outcomes required.
+
     models:
       direct_assessment: Direct Assessment
   activities:

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -39,11 +39,19 @@ en:
           details: Details
       update:
         success: Assessment updated successfully.
+    assignments:
+      create:
+        success: Assignment added and matched to Outcome "%{label}"
+      new:
+        add: Add
+        assignment: Assignment
+        problem: Problem
     coverages:
       new:
         add_outcome: Add an Outcome
     outcome_coverages:
       outcome_coverage:
+        add_assignment: Add Assignment
         outcome: Outcome %{label}
     dashboard:
       show:

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -52,6 +52,8 @@ en:
     outcome_coverages:
       outcome_coverage:
         add_assignment: Add Assignment
+        assignment_name: In %{name}
+        assignment_problem: on %{problem}
         outcome: Outcome %{label}
     dashboard:
       show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
       resources :coverages, only: [:new, :create]
     end
 
+    resources :outcome_coverages, only: [] do
+      resources :assignments, only: [:new, :create]
+    end
+
     resources :assessments, only: [:new, :create, :edit, :update] do
       resource :archive, only: [:create, :destroy]
     end

--- a/db/migrate/20170518162321_create_assignments.rb
+++ b/db/migrate/20170518162321_create_assignments.rb
@@ -1,0 +1,10 @@
+class CreateAssignments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :assignments do |t|
+      t.timestamps null: false
+      t.references :outcome_coverage, index: true, foreign_key: true, null: false
+      t.string :name, null: false
+      t.string :problem, null: false
+    end
+  end
+end

--- a/db/migrate/20170518162321_create_assignments.rb
+++ b/db/migrate/20170518162321_create_assignments.rb
@@ -4,7 +4,7 @@ class CreateAssignments < ActiveRecord::Migration[5.0]
       t.timestamps null: false
       t.references :outcome_coverage, index: true, foreign_key: true, null: false
       t.string :name, null: false
-      t.string :problem, null: false
+      t.string :problem
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20170518162321) do
     t.datetime "updated_at",          null: false
     t.integer  "outcome_coverage_id", null: false
     t.string   "name",                null: false
-    t.string   "problem",             null: false
+    t.string   "problem"
     t.index ["outcome_coverage_id"], name: "index_assignments_on_outcome_coverage_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517153248) do
+ActiveRecord::Schema.define(version: 20170518162321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,15 @@ ActiveRecord::Schema.define(version: 20170517153248) do
     t.integer  "results_count",       default: 0,     null: false
     t.index ["archived"], name: "index_assessments_on_archived", using: :btree
     t.index ["subject_id"], name: "index_assessments_on_subject_id", using: :btree
+  end
+
+  create_table "assignments", force: :cascade do |t|
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.integer  "outcome_coverage_id", null: false
+    t.string   "name",                null: false
+    t.string   "problem",             null: false
+    t.index ["outcome_coverage_id"], name: "index_assignments_on_outcome_coverage_id", using: :btree
   end
 
   create_table "courses", force: :cascade do |t|
@@ -159,6 +168,7 @@ ActiveRecord::Schema.define(version: 20170517153248) do
   add_foreign_key "alignments", "outcomes"
   add_foreign_key "alignments", "standard_outcomes"
   add_foreign_key "assessments", "subjects"
+  add_foreign_key "assignments", "outcome_coverages"
   add_foreign_key "courses", "departments", on_delete: :restrict
   add_foreign_key "coverages", "courses"
   add_foreign_key "coverages", "subjects"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -103,4 +103,9 @@ FactoryGirl.define do
       "user-#{n}@example.com"
     end
   end
+
+  factory :coverage do
+    course
+    subject
+  end
 end

--- a/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
+++ b/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+feature "User adds assignment to outcome coverage" do
+  scenario "successfully" do
+    outcome = create(:outcome)
+    course = outcome.course
+    coverage = create(:coverage, course: course, outcomes: [outcome])
+    user = user_with_assessments_access_to(course.department)
+
+    visit manage_assessments_course_path(course.id, as: user)
+
+    expect(page).to have_content(course.name)
+    expect(page).to have_content(course.number)
+
+    click_on t("manage_assessments.outcome_coverages.outcome_coverage.add_assignment")
+    fill_in t("manage_assessments.assignments.new.assignment"), with: "Problem Set 2"
+    fill_in t("manage_assessments.assignments.new.problem"), with: "Question 4"
+    click_on t("manage_assessments.assignments.new.add")
+
+    expect(page).to have_content(course.name)
+    expect(page).to have_content(course.number)
+
+    within("#matched_outcomes") do
+      expect(page).to have_content("Problem Set 2")
+      expect(page).to have_content("Question 4")
+    end
+  end
+end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe Assignment do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+  end
+
+  describe "associations" do
+    it { should belong_to(:outcome_coverage) }
+    it { should have_one(:outcome).through(:outcome_coverage) }
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/zTh1BDd2)
A user can now add an assignment to specific outcome coverages. Each outcome coverage can only have one assignment associated with it. Currently, assignments can only be added; they cannot be edited or deleted. 

![screen shot 2017-05-23 at 11 45 31 am](https://cloud.githubusercontent.com/assets/9501674/26362896/62620fce-3fad-11e7-9190-3f0863dcb860.png)
