### PR TITLE
Design for the add assignment madlib form

### DIFF
--- a/app/assets/javascripts/input_marking.js
+++ b/app/assets/javascripts/input_marking.js
@@ -1,0 +1,20 @@
+$(function(){
+  var markInput = function() {
+    input = $(this)
+    value = $.trim(input.val());
+
+    if (value) {
+      input.
+        addClass("has-items").
+        removeClass("is-empty");
+    } else {
+      input.
+        addClass("is-empty").
+        removeClass("has-items");
+    }
+  };
+
+  $("input[type='text']").
+    on("blur", markInput).
+    each(markInput);
+});

--- a/app/assets/stylesheets/components/_selectize-madlib.scss
+++ b/app/assets/stylesheets/components/_selectize-madlib.scss
@@ -1,12 +1,18 @@
 .madlib {
-  .selectize-control .selectize-input {
+  .selectize-control .selectize-input,
+  #{$all-text-inputs} {
     @include padding($smallest-spacing null);
+    @include placeholder {
+      color: $medium-gray;
+    }
+
     background-color: transparent;
     background-image: none;
     border: 0;
     border-bottom: $thick-border-width solid $base-border-color;
     border-radius: 0;
     box-shadow: none;
+    color: $mit-red;
     cursor: pointer;
     font-family: $sans-serif-narrow;
     font-size: modular-scale(2, $base-font-size);
@@ -30,7 +36,17 @@
     }
   }
 
-  .input.select {
+  #{$all-text-inputs} {
+    margin-bottom: $smallest-spacing;
+    padding-left: $smallest-spacing;
+  }
+
+  label {
+    padding-left: $small-spacing;
+  }
+
+  .input.select,
+  .input {
     display: flex;
     flex-direction: column-reverse;
     margin-bottom: $medium-spacing;

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,7 +2,9 @@ class Assignment < ActiveRecord::Base
   belongs_to :outcome_coverage
 
   has_one :outcome, through: :outcome_coverage
+
   delegate :department, to: :outcome
+  delegate :course_number, :course_name, to: :outcome
 
   validates :name, presence: true
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -17,6 +17,8 @@ class Outcome < ActiveRecord::Base
     reject_if: ->(attributes) { attributes[:level].blank? },
     allow_destroy: true
 
+  delegate :number, :name, to: :course, prefix: true
+
   validates :label, presence: true, uniqueness: { scope: :course_id },
     length: { maximum: 5 }
   validates :nickname, presence: true, uniqueness: { scope: :course_id }

--- a/app/views/manage_assessments/assignments/new.html.erb
+++ b/app/views/manage_assessments/assignments/new.html.erb
@@ -1,5 +1,21 @@
-<%= simple_form_for @assignment, url: manage_assessments_outcome_coverage_assignments_path do |form| %>
-  <%= form.input :name, label: t(".assignment") %>
-  <%= form.input :problem, label: t(".problem") %>
-  <%= form.submit t(".add") %>
+<%= content_for :full_bleed do %>
+  <div class="madlib-header">
+    <h1 class="headline-narrow">
+      <%= t(".headline") %>
+    </h1>
+    <h2 class="headline-narrow-subhead">
+      <%= @assignment.course_number %>
+      &middot;
+      <%= @assignment.course_name %>
+    </h2>
+  </div>
+<% end %>
+
+
+<%= simple_form_for @assignment, html: { class: "madlib" }, url: manage_assessments_outcome_coverage_assignments_path do |form| %>
+  <%= form.input :name %>
+  <%= form.input :problem %>
+  <%= form.submit %>
+
+  <%= link_to t("helpers.cancel_button"), :back %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
     attributes:
       alignment:
         _destroy: Remove
+      assignment:
+        name: Assignment
       direct_assessment:
         outcome_ids: Outcomes
       result:

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -44,8 +44,7 @@ en:
         success: Assignment added and matched to Outcome "%{label}"
       new:
         add: Add
-        assignment: Assignment
-        problem: Problem
+        headline: Add assignment
     coverages:
       new:
         add_outcome: Add an Outcome

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,6 +1,8 @@
 en:
   helpers:
     submit:
+      assignment:
+        create: Add
       coverage:
         create: Add
   simple_form:
@@ -41,6 +43,10 @@ en:
           question you are entering data for.
         percentage: The percent of students who meet the minimum criteria
           for this item.
+    placeholders:
+      assignment:
+        name: Problem Set 4
+        problem: Problem 4
     prompts:
       alignments:
         level: No alignment

--- a/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
+++ b/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
@@ -13,9 +13,9 @@ feature "User adds assignment to outcome coverage" do
     expect(page).to have_content(course.number)
 
     click_on t("manage_assessments.outcome_coverages.outcome_coverage.add_assignment")
-    fill_in t("manage_assessments.assignments.new.assignment"), with: "Problem Set 2"
-    fill_in t("manage_assessments.assignments.new.problem"), with: "Question 4"
-    click_on t("manage_assessments.assignments.new.add")
+    fill_in :assignment_name, with: "Problem Set 2"
+    fill_in :assignment_problem, with: "Question 4"
+    click_on t("helpers.submit.coverage.create")
 
     expect(page).to have_content(course.name)
     expect(page).to have_content(course.number)


### PR DESCRIPTION
This PR makes the add a class form match the styles established in the
add a class/outcome form.

![add assignment](https://cloud.githubusercontent.com/assets/5566826/26424099/08ce2bc2-409e-11e7-8d4c-50fb39702f10.gif)

https://trello.com/c/QW12ljja