### PR TITLE
User can add attachments to an assignment

### DIFF
--- a/app/controllers/manage_assessments/assignments_controller.rb
+++ b/app/controllers/manage_assessments/assignments_controller.rb
@@ -8,7 +8,7 @@ class ManageAssessments::AssignmentsController < ApplicationController
   def create
     @assignment = outcome_coverage.build_assignment(assignment_params)
     authorize(@assignment)
-    
+
     if @assignment.save
       redirect_to manage_assessments_course_path(outcome_coverage.coverage.course),
         success: t(".success", label: outcome_coverage.outcome.label)

--- a/app/controllers/manage_assessments/assignments_controller.rb
+++ b/app/controllers/manage_assessments/assignments_controller.rb
@@ -1,13 +1,14 @@
 class ManageAssessments::AssignmentsController < ApplicationController
   def new
     @assignment = outcome_coverage.build_assignment
+    @assignment.attachments.build
     authorize(@assignment)
   end
 
   def create
     @assignment = outcome_coverage.build_assignment(assignment_params)
     authorize(@assignment)
-
+    
     if @assignment.save
       redirect_to manage_assessments_course_path(outcome_coverage.coverage.course),
         success: t(".success", label: outcome_coverage.outcome.label)
@@ -23,6 +24,6 @@ class ManageAssessments::AssignmentsController < ApplicationController
   end
 
   def assignment_params
-    params.require(:assignment).permit(:name, :problem)
+    params.require(:assignment).permit(:name, :problem, attachments_attributes: [:file])
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,9 @@
 class Assignment < ActiveRecord::Base
   belongs_to :outcome_coverage
 
+  has_many :attachments
+  accepts_nested_attributes_for :attachments
+
   has_one :outcome, through: :outcome_coverage
 
   delegate :department, to: :outcome

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,7 +1,7 @@
 class Assignment < ActiveRecord::Base
   belongs_to :outcome_coverage
 
-  has_many :attachments
+  has_many :attachments, as: :attachable
   accepts_nested_attributes_for :attachments
 
   has_one :outcome, through: :outcome_coverage

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,9 +1,9 @@
 class Attachment < ActiveRecord::Base
-  belongs_to :coverage
+  belongs_to :attachable, polymorphic: true
 
   has_attached_file :file,
     url: "/attachments/:id",
-    path: ":attachments_root/coverage/:coverage_id/:id/:filename",
+    path: ":attachments_root/:attachable_type/:attachable_id/:id/:filename",
     s3_permissions: :private
 
   validates_attachment_content_type :file, content_type: /\Aapplication\/pdf\z/

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -4,7 +4,7 @@ class Coverage < ActiveRecord::Base
 
   has_many :outcome_coverages
   has_many :outcomes, through: :outcome_coverages
-  has_many :attachments
+  has_many :attachments, as: :attachable
 
   accepts_nested_attributes_for :outcome_coverages,
     allow_destroy: true,

--- a/app/views/manage_assessments/assignments/_attachment_fields.html.erb
+++ b/app/views/manage_assessments/assignments/_attachment_fields.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :file, as: :file %>

--- a/app/views/manage_assessments/assignments/new.html.erb
+++ b/app/views/manage_assessments/assignments/new.html.erb
@@ -15,5 +15,13 @@
   <%= form.input :name %>
   <%= form.input :problem %>
 
+  <%= form.simple_fields_for :attachments do |fields| %>
+    <%= fields.input :file %>
+  <% end %>
+
+  <div>
+    <%= link_to_add_association "Attach student work", form, :attachments %>
+  </div>
+
   <%= render "manage_assessments/madlib_controls", form: form %>
 <% end %>

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -6,8 +6,12 @@ Paperclip.interpolates :attachments_root do |attachment, style|
   end
 end
 
-Paperclip.interpolates :coverage_id do |attachment, style|
-  attachment.instance.coverage.id
+Paperclip.interpolates :attachable_id do |attachment, style|
+  attachment.instance.attachable.id
+end
+
+Paperclip.interpolates :attachable_type do |attachment, style|
+  attachment.instance.attachable.model_name.singular
 end
 
 if Rails.env.production? || Rails.env.staging?

--- a/db/migrate/20170530182453_add_attachable_to_attachments.rb
+++ b/db/migrate/20170530182453_add_attachable_to_attachments.rb
@@ -1,0 +1,11 @@
+class AddAttachableToAttachments < ActiveRecord::Migration[5.1]
+  def change
+    change_table :attachments do |t|
+      t.integer :attachable_id, null: false
+      t.string :attachable_type, null: false
+      t.index [:attachable_type, :attachable_id]
+    end
+
+    remove_reference :attachments, :coverage
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170523184804) do
+ActiveRecord::Schema.define(version: 20170530182453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,10 +54,11 @@ ActiveRecord::Schema.define(version: 20170523184804) do
     t.string "file_content_type", null: false
     t.integer "file_file_size", null: false
     t.datetime "file_updated_at", null: false
-    t.integer "coverage_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["coverage_id"], name: "index_attachments_on_coverage_id"
+    t.integer "attachable_id", null: false
+    t.string "attachable_type", null: false
+    t.index ["attachable_type", "attachable_id"], name: "index_attachments_on_attachable_type_and_attachable_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -174,7 +175,6 @@ ActiveRecord::Schema.define(version: 20170523184804) do
   add_foreign_key "alignments", "standard_outcomes"
   add_foreign_key "assessments", "subjects"
   add_foreign_key "assignments", "outcome_coverages"
-  add_foreign_key "attachments", "coverages"
   add_foreign_key "courses", "departments", on_delete: :restrict
   add_foreign_key "coverages", "courses"
   add_foreign_key "coverages", "subjects"

--- a/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
+++ b/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
@@ -17,7 +17,6 @@ feature "User adds assignment to outcome coverage" do
     fill_in :assignment_problem, with: "Question 4"
     click_on "Attach student work"
     attach("spec/fixtures/attachments/example.pdf")
-    click_on t("manage_assessments.assignments.new.add")
     click_on t("helpers.submit.coverage.create")
 
     expect(page).to have_content(course.name)

--- a/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
+++ b/spec/features/user_adds_an_assignment_to_a_coverage_spec.rb
@@ -15,6 +15,9 @@ feature "User adds assignment to outcome coverage" do
     click_on t("manage_assessments.outcome_coverages.outcome_coverage.add_assignment")
     fill_in :assignment_name, with: "Problem Set 2"
     fill_in :assignment_problem, with: "Question 4"
+    click_on "Attach student work"
+    attach("spec/fixtures/attachments/example.pdf")
+    click_on t("manage_assessments.assignments.new.add")
     click_on t("helpers.submit.coverage.create")
 
     expect(page).to have_content(course.name)
@@ -24,5 +27,9 @@ feature "User adds assignment to outcome coverage" do
       expect(page).to have_content("Problem Set 2")
       expect(page).to have_content("Question 4")
     end
+  end
+
+  def attach(path)
+    all("input.file").last.set(File.absolute_path(path))
   end
 end

--- a/spec/fixtures/attachments/example.pdf
+++ b/spec/fixtures/attachments/example.pdf
@@ -1,0 +1,58 @@
+%PDF-1.1
+%¥±ë
+
+1 0 obj
+  << /Type /Catalog
+     /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Pages
+     /Kids [3 0 R]
+     /Count 1
+     /MediaBox [0 0 300 144]
+  >>
+endobj
+
+3 0 obj
+  <<  /Type /Page
+      /Parent 2 0 R
+      /Resources
+       << /Font
+           << /F1
+               << /Type /Font
+                  /Subtype /Type1
+                  /BaseFont /Times-Roman
+               >>
+           >>
+       >>
+      /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  << /Length 55 >>
+stream
+  BT
+    /F1 18 Tf
+    0 0 Td
+    (Hello World) Tj
+  ET
+endstream
+endobj
+
+xref
+0 5
+0000000000 65535 f 
+0000000018 00000 n 
+0000000077 00000 n 
+0000000178 00000 n 
+0000000457 00000 n 
+trailer
+  <<  /Root 1 0 R
+      /Size 5
+  >>
+startxref
+565
+%%EOF


### PR DESCRIPTION
[Trello card](https://trello.com/c/jv1d2jDD). This branch allows users to add multiple attachments to an assignment when creating an assignment. The attachment of files is handled using the [Paperclip gem](https://github.com/thoughtbot/paperclip). Currently users can only add files; they cannot edit or delete them. 

![screen shot 2017-05-25 at 11 55 05 am](https://cloud.githubusercontent.com/assets/9501674/26458369/077dc6da-4141-11e7-9104-db1b75469aca.png)


