### PR TITLE
Refactor split tabs

### DIFF
--- a/app/assets/javascripts/split_tabs.js
+++ b/app/assets/javascripts/split_tabs.js
@@ -1,29 +1,21 @@
 $(function() {
-  var splitTabsContainer = ".split-tabs";
-  var splitTab = ".split-tab";
-  var splitTabPanel = ".split-tab-panel";
   var activeClass = "is-active";
-  var transitionTime = 300;
+  var transitionTimeInMilliSeconds = 300;
 
-  $(splitTab + ":first-child")
-    .addClass(activeClass)
-    .closest(splitTabsContainer)
-    .siblings(splitTabPanel + ":first-of-type")
-    .show();
+  var activateTab = function() {
+    var targetTabControl = $(this);
+    var targetTabContent = $("[data-content='" + targetTabControl.data("tab") + "']");
+    var otherTabControls = $("[data-tab]").not(targetTabControl);
+    var otherTabContent = $("[data-content]").not(targetTabContent);
 
-  $(splitTab).click(function() {
-    $(this)
-      .siblings(splitTab)
-      .removeClass(activeClass)
-      .closest(splitTabsContainer)
-      .siblings(splitTabPanel)
-      .hide();
+    targetTabControl.addClass(activeClass);
+    otherTabControls.removeClass(activeClass);
 
-    $(this)
-      .addClass(activeClass)
-      .closest(splitTabsContainer)
-      .siblings(splitTabPanel)
-      .eq($(this).index(splitTab))
-      .fadeIn(transitionTime);
-  });
+    targetTabContent.fadeIn(transitionTimeInMilliSeconds);
+    otherTabContent.hide();
+  };
+
+  $("[data-tab]")
+    .on('click', activateTab)
+    .first().trigger('click');
 });

--- a/app/views/manage_assessments/courses/show.html.erb
+++ b/app/views/manage_assessments/courses/show.html.erb
@@ -7,17 +7,17 @@
   </h2>
 
   <nav class="split-tabs">
-    <%= link_to "#!", class: "split-tab" do %>
+    <%= link_to "#!", class: "split-tab", data: { tab: "matched" } do %>
       <%= t(".matched") %>
       <span class="split-tab-digit"><%= @course.covered_outcomes_count %></span>
     <% end %>
-    <%= link_to "#!", class: "split-tab" do %>
+    <%= link_to "#!", class: "split-tab", data: { tab: "unmatched" } do %>
       <%= t(".unmatched") %>
       <span class="split-tab-digit"><%= @course.uncovered_outcomes_count %></span>
     <% end %>
   </nav>
 
-  <section id="matched_outcomes" class="split-tab-panel">
+  <section id="matched_outcomes" class="split-tab-panel" data-content="matched">
     <div class="container">
       <%= render @course.coverages %>
 
@@ -29,7 +29,7 @@
     </div>
   </section>
 
-  <section class="outcome-cards split-tab-panel">
+  <section class="outcome-cards split-tab-panel" data-content="unmatched">
     <div class="container">
       <% @course.outcomes.each do |outcome| %>
         <%= render "outcome_status", outcome: outcome %>

--- a/spec/features/user_views_outcome_coverage_status_spec.rb
+++ b/spec/features/user_views_outcome_coverage_status_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 feature "user views outcome coverage status for a course" do
-  scenario "sees which outcomes are covered and uncovered" do
+  scenario "sees which outcomes are covered and uncovered", js: true do
     course = create(:course)
     covered_outcome, uncovered_outcome = create_pair(:outcome, course: course)
     create(:coverage, course: course, outcomes: [covered_outcome])
     user = user_with_assessments_access_to(course.department)
 
     visit manage_assessments_course_path(course, as: user)
+    click_on "Unmatched Outcomes"
 
     expect(matched_outcome_cards).to have_content(covered_outcome.nickname)
     expect(unmatched_outcome_cards).to have_content(uncovered_outcome.nickname)


### PR DESCRIPTION
The previous split-tab JavaScript was heavily dependent on the structure
of the markup. This implementation is instead dependent on being wired
up via data attributes.

The tab controls themselves must have a `data-tab` attribute set to some
identifier. The associated content must have a `data-content` with the
value set to the same value.

After wiring up the event handlers on the tabs, we trigger a click on
the first tab to set it as the active tab.