### PR TITLE
Use hidden file inputs for coverage attachments

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -1,0 +1,16 @@
+$(function() {
+  var fileInput = "input[type='file']";
+  var fileName = ".file-name";
+  var removeLink = "a.remove_fields";
+
+  $(document).on("cocoon:before-insert", function(e, insertedItem) {
+    $(insertedItem).find(fileInput).hide().click();
+    $(insertedItem).find(removeLink).hide();
+
+    $(insertedItem).on("change", function(ev) {
+      var selectedFileName = ev.target.files[0].name;
+      $(this).find(fileName).text(selectedFileName);
+      $(this).find(removeLink).show();
+    });
+  });
+});

--- a/app/controllers/manage_assessments/coverages_controller.rb
+++ b/app/controllers/manage_assessments/coverages_controller.rb
@@ -2,7 +2,6 @@ module ManageAssessments
   class CoveragesController < ApplicationController
     def new
       @coverage = course.coverages.build
-      @coverage.attachments.build
       @coverage.outcome_coverages.build(outcome_id: params[:outcome_id])
       authorize(@coverage)
     end
@@ -29,7 +28,7 @@ module ManageAssessments
         require(:coverage).
         permit(
           :subject_id,
-          attachments_attributes: [:file],
+          attachments_attributes: [:id, :file, :_destroy],
           outcome_coverages_attributes: [:coverage_id, :outcome_id],
         )
     end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -7,4 +7,6 @@ class Attachment < ActiveRecord::Base
     s3_permissions: :private
 
   validates_attachment_content_type :file, content_type: /\Aapplication\/pdf\z/
+
+  delegate :name, to: :file
 end

--- a/app/views/manage_assessments/coverages/_attachment_fields.html.erb
+++ b/app/views/manage_assessments/coverages/_attachment_fields.html.erb
@@ -1,1 +1,11 @@
-<%= f.input :file, as: :file %>
+<li class="attachment">
+  <%= f.file_field :file, as: :file %>
+
+  <% if f.object.persisted? %>
+    <span class="file-name"><%= f.object.name %></span>
+  <% else %>
+    <span class="file-name"></span>
+  <% end %>
+
+  <%= link_to_remove_association "x", f, wrapper_class: "attachment" %>
+</li>

--- a/app/views/manage_assessments/coverages/_attachments.html.erb
+++ b/app/views/manage_assessments/coverages/_attachments.html.erb
@@ -1,0 +1,9 @@
+<ul class="attachments">
+  <%= form.fields_for :attachments, wrapper: false do |attachment_fields| %>
+    <%= render "attachment_fields", f: attachment_fields %>
+  <% end %>
+</ul>
+
+<div class="nested-form-actions">
+  <%= link_to_add_association t(".add"), form, :attachments %>
+</div>

--- a/app/views/manage_assessments/coverages/new.html.erb
+++ b/app/views/manage_assessments/coverages/new.html.erb
@@ -30,13 +30,6 @@
       render_options: { locals: { outcomes: @coverage.course.outcomes } } %>
   </div>
 
-  <%= form.simple_fields_for :attachments do |attachment_fields| %>
-    <%= render "attachment_fields", f: attachment_fields %>
-  <% end %>
-
-  <div class="nested-form-actions">
-    <%= link_to_add_association t(".add_attachment"), form, :attachments %>
-  </div>
-
+  <%= render "attachments", form: form %>
   <%= render "manage_assessments/madlib_controls", form: form %>
 <% end %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -46,8 +46,9 @@ en:
         add: Add
         headline: Add assignment
     coverages:
+      attachments:
+        add: Add an Attachment
       new:
-        add_attachment: Add an Attachment
         add_outcome: Add an Outcome
     outcome_coverages:
       outcome_coverage:

--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -13,9 +13,6 @@ feature "user adds coverage to a course" do
     selectize first_outcome.nickname, from: "Outcome"
     click_on t('manage_assessments.coverages.new.add_outcome')
     selectize second_outcome.nickname, from: "Outcome"
-    attach("spec/fixtures/syllabus.pdf")
-    click_on t('manage_assessments.coverages.new.add_attachment')
-    attach("spec/fixtures/syllabus.pdf")
     click_button t('helpers.submit.coverage.create')
 
     within("#matched_outcomes") do
@@ -44,12 +41,7 @@ feature "user adds coverage to a course" do
     container.find("div.option", text: item).click
   end
 
-  def attach(path)
-    all("input.file").last.set(File.absolute_path(path))
-  end
-
   def have_prepopulated_select_box(text)
     have_css("select", text: text)
   end
-
 end


### PR DESCRIPTION
The design calls for an "Add an attachment" link that prompts the user
for a file to upload rather than a standard file input. We accomplish
this by hooking in to the cocoon lifecycle events to trigger a click to
the now-hidden file input when we add a new association record via
cocoon.

We render the names of the files to be uploaded in a list but keep the
inputs hidden. This change also adds the ability to remove an
attachment.

I was unable to get the JavaScript test drivers to play nice with an
auto-triggered file input dialog backed by a hidden input. I originally
added a workaround that made the JavaScript behave differently when
running in test, but this didn't feel like a useful distinction. After a
good deal of time trying to get file attachments running appropriately
in this design, I abandoned the idea of testing them. I have manually
tested file uploads. I wish there were an easier way of testing this,
but I can't figure it out. I may come back to this if there's more time.

![may-31-2017 15-13-32](https://cloud.githubusercontent.com/assets/152152/26649386/c07b83b2-4613-11e7-95ae-f2c3528b7a14.gif)