### PR TITLE
User can edit coverage for a course

### DIFF
--- a/app/controllers/manage_assessments/coverages_controller.rb
+++ b/app/controllers/manage_assessments/coverages_controller.rb
@@ -6,6 +6,11 @@ module ManageAssessments
       authorize(@coverage)
     end
 
+    def edit
+      @coverage = Coverage.find(params[:id])
+      authorize(@coverage)
+    end
+
     def create
       @coverage = course.coverages.build(coverage_params)
       authorize(@coverage)
@@ -14,6 +19,17 @@ module ManageAssessments
         redirect_to manage_assessments_course_path(course)
       else
         render :new
+      end
+    end
+
+    def update
+      @coverage = Coverage.find(params[:id])
+      authorize(@coverage)
+
+      if @coverage.update_attributes(coverage_params)
+        redirect_to manage_assessments_course_path(@coverage.course)
+      else
+        render :edit
       end
     end
 
@@ -29,7 +45,7 @@ module ManageAssessments
         permit(
           :subject_id,
           attachments_attributes: [:id, :file, :_destroy],
-          outcome_coverages_attributes: [:coverage_id, :outcome_id],
+          outcome_coverages_attributes: [:id, :outcome_id],
         )
     end
   end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -5,4 +5,6 @@ class OutcomeCoverage < ActiveRecord::Base
   has_one :assignment
 
   delegate :label, :nickname, to: :outcome, prefix: true
+
+  validates :outcome_id, uniqueness: { scope: :coverage_id }
 end

--- a/app/policies/coverage_policy.rb
+++ b/app/policies/coverage_policy.rb
@@ -2,4 +2,12 @@ class CoveragePolicy < ApplicationPolicy
   def create?
     user.manage_assessments?(record.course.department)
   end
+
+  def edit?
+    create?
+  end
+
+  def update?
+    create?
+  end
 end

--- a/app/views/manage_assessments/coverages/_coverage.html.erb
+++ b/app/views/manage_assessments/coverages/_coverage.html.erb
@@ -6,5 +6,6 @@
     <%= coverage.subject.title %>
   </h2>
 
-  <%= render coverage.outcome_coverages %>
+    <%= render coverage.outcome_coverages %>
+    <%= link_to t(".add_another_outcome"), edit_manage_assessments_course_coverage_path(coverage, course_id: coverage.course.id) %>
 </div>

--- a/app/views/manage_assessments/coverages/_form.html.erb
+++ b/app/views/manage_assessments/coverages/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form.input :subject_id,
+  collection: Subject.sorted_by_number,
+  label_method: :to_s %>
+
+<%= form.simple_fields_for :outcome_coverages do |outcome_coverage_fields| %>
+  <%= outcome_coverage_fields.input :outcome_id,
+    collection: @coverage.course.outcomes,
+    label_method: :to_short_s,
+    required: outcome_coverage_fields.options[:child_index] == 0 %>
+<% end %>
+
+<div class="nested-form-actions">
+  <%= link_to_add_association "Add Outcome",
+    form,
+    :outcome_coverages,
+    render_options: { locals: { outcomes: @coverage.course.outcomes } } %>
+</div>
+
+<%= form.simple_fields_for :attachments do |attachment_fields| %>
+  <%= render "attachment_fields", f: attachment_fields %>
+<% end %>
+
+<div class="nested-form-actions">
+  <%= link_to_add_association "Attach student work", form, :attachments %>
+</div>
+
+<%= render "manage_assessments/madlib_controls", form: form %>

--- a/app/views/manage_assessments/coverages/edit.html.erb
+++ b/app/views/manage_assessments/coverages/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :full_bleed do %>
   <div class="madlib-header">
     <h1 class="headline-narrow">
-      Add a class
+      Add and Edit Outcomes
     </h1>
     <h2 class="headline-narrow-subhead">
       <%= @coverage.course.number %>
@@ -11,6 +11,6 @@
   </div>
 <% end %>
 
-<%= simple_form_for @coverage, html: { class: "madlib" }, url: manage_assessments_course_coverages_path(course_id: @coverage.course.id) do |form| %>
-    <%= render "form", form: form %>
+<%= simple_form_for @coverage, html: { class: "madlib" }, url: manage_assessments_course_coverage_path(course_id: @coverage.course.id) do |form| %>
+  <%= render "form", form: form %>
 <% end %>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -49,7 +49,9 @@ en:
       attachments:
         add: Add an Attachment
       new:
-        add_outcome: Add an Outcome
+        add_outcome: Add Outcome
+      coverage:
+        add_another_outcome: Add another outcome
     outcome_coverages:
       outcome_coverage:
         add_assignment: Add an Assignment

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -5,6 +5,7 @@ en:
         create: Add
       coverage:
         create: Add
+        update: Update
   simple_form:
     "yes": 'Yes'
     "no": 'No'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
     resources :courses, only: [:index, :show] do
       resources :assessments, only: [:index]
-      resources :coverages, only: [:new, :create]
+      resources :coverages, only: [:new, :edit, :create, :update]
     end
 
     resources :outcome_coverages, only: [] do

--- a/spec/features/user_edits_course_coverage_spec.rb
+++ b/spec/features/user_edits_course_coverage_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+feature "User edits course coverage" do
+  scenario "by adding another outcome successfully" do
+    course = create(:course)
+    outcome = create(:outcome)
+    coverage = create(:coverage, course: course, outcomes: [outcome])
+    user = user_with_assessments_access_to(course.department)
+
+    visit manage_assessments_course_path(course.id, as: user)
+    click_on t("manage_assessments.coverages.coverage.add_another_outcome")
+
+    expect(page).to have_css("h1.headline-narrow", text: "Add and Edit Outcomes")
+    expect(page).to have_prepopulated_select_box(coverage.subject.title)
+  end
+
+  def have_prepopulated_select_box(text)
+    have_css("select", text: text)
+  end
+end

--- a/spec/models/outcome_coverage_spec.rb
+++ b/spec/models/outcome_coverage_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe OutcomeCoverage do
+  it "validates that outcome coverage is unique per coverage" do
+    course = create(:course)
+    outcome = create(:outcome)
+    coverage = create(:coverage, course: course, outcomes: [outcome])
+    outcome_coverage = OutcomeCoverage.new(coverage: coverage, outcome: outcome)
+
+    expect(outcome_coverage).to validate_uniqueness_of(:outcome_id).scoped_to(:coverage_id)
+  end
+end


### PR DESCRIPTION
A user can now add an outcome to an existing coverage or change an existing outcome to a different outcome. To accomplish this functionality, `edit` and `update` where added to the `Coverages` Controller. A user cannot yet delete an outcome from a coverage. If a user tries to add a duplicate outcome to a coverage, she will be prompted to select another outcome.

**Add Another Outcome button added**
![screen shot 2017-06-01 at 1 11 41 pm](https://cloud.githubusercontent.com/assets/9501674/26691684/0f86e39e-46cc-11e7-8711-05e37123dd6f.png)

**Edit form rendered with pre-populated fields**
![screen shot 2017-06-01 at 1 12 01 pm](https://cloud.githubusercontent.com/assets/9501674/26691685/0f898586-46cc-11e7-9ce2-6881b72213fe.png)