### PR TITLE
Fix dynamic association insertion bugs

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -3,7 +3,7 @@ $(function() {
   var fileName = ".file-name";
   var removeLink = "a.remove_fields";
 
-  $(document).on("cocoon:before-insert", function(e, insertedItem) {
+  $(document).on("cocoon:before-insert", ".attachments", function(e, insertedItem) {
     $(insertedItem).find(fileInput).hide().click();
     $(insertedItem).find(removeLink).hide();
 

--- a/app/views/manage_assessments/coverages/_attachments.html.erb
+++ b/app/views/manage_assessments/coverages/_attachments.html.erb
@@ -5,5 +5,8 @@
 </ul>
 
 <div class="nested-form-actions">
-  <%= link_to_add_association t(".add"), form, :attachments %>
+  <%= link_to_add_association t(".add"), form, :attachments, data: {
+    association_insertion_method: "append",
+    association_insertion_node: ".attachments"
+  } %>
 </div>


### PR DESCRIPTION
* We were using cocoon in an attempt to add associated attachments
inside a `ul`, but they were being added as siblings to the `ul`
instead. We can use data attributes to better control this through
cocoon.

* We were mistakenly running all cocoon insertions through the
attachment-specific JavaScript, which was resulting in some JavaScript
errors when trying to dynamically add outcomes to a coverage.