### PR TITLE
Validate uniqueness of subject per course

### DIFF
--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -14,7 +14,7 @@ class Coverage < ActiveRecord::Base
     allow_destroy: true,
     reject_if: :all_blank
 
-  validates :subject_id, presence: true
+  validates :subject_id, presence: true, uniqueness: { scope: :course_id }
   validate :must_have_outcomes
 
   private

--- a/db/migrate/20170601183541_add_unique_index_to_coverages.rb
+++ b/db/migrate/20170601183541_add_unique_index_to_coverages.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToCoverages < ActiveRecord::Migration[5.1]
+  def change
+    add_index :coverages, [:course_id, :subject_id], unique: true
+    remove_index :coverages, [:course_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170530182453) do
+ActiveRecord::Schema.define(version: 20170601183541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 20170530182453) do
     t.datetime "updated_at", null: false
     t.integer "course_id", null: false
     t.integer "subject_id", null: false
-    t.index ["course_id"], name: "index_coverages_on_course_id"
+    t.index ["course_id", "subject_id"], name: "index_coverages_on_course_id_and_subject_id", unique: true
     t.index ["subject_id"], name: "index_coverages_on_subject_id"
   end
 

--- a/spec/models/coverage_spec.rb
+++ b/spec/models/coverage_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe Coverage do
+  it "validates subject is unique per course" do
+    course = create(:course)
+    outcome = create(:outcome, course: course)
+    create(:coverage, course: course, outcomes: [outcome])
+    coverage = Coverage.new
+
+    expect(coverage).to validate_uniqueness_of(:subject_id).scoped_to(:course_id)
+  end
+end


### PR DESCRIPTION
We want only a single coverage for each subject per course. This change
enforces that coverage have unique subject ids scoped to a given course
id.

Attempts to add a duplicate subject will now hit a validation error. We
currently aren't displaying validation errors at all, so we'll have to
look at that as a separate card.