### PR TITLE
Fix intermittent test failure

### DIFF
--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 feature "User views activity feed" do
   around do |example|
     PaperTrail.enabled = true
+    PaperTrail.enabled_for_controller = true
     example.run
+    PaperTrail.enabled_for_controller = false
     PaperTrail.enabled = false
   end
 


### PR DESCRIPTION
The feature spec `user_visits_activity_feed_spec.rb` would fail intermittently on randomized seed 9406, which ran the `application_controller_spec.rb` just before running the failing test. The fix was to add `PaperTrail.enabled_for_controller = true` and `PaperTrail.enabled_for_controller = false` to `user_visits_activity_feed_spec.rb` to ensure that the PaperTrail default settings do not interfere with the anonymous controller in `application_controller_spec.rb`.