### PR TITLE
Allow assignment attachments to be removed

### DIFF
--- a/app/controllers/manage_assessments/assignments_controller.rb
+++ b/app/controllers/manage_assessments/assignments_controller.rb
@@ -23,6 +23,10 @@ class ManageAssessments::AssignmentsController < ApplicationController
   end
 
   def assignment_params
-    params.require(:assignment).permit(:name, :problem, attachments_attributes: [:file])
+    params.require(:assignment).permit(
+      :name,
+      :problem,
+      attachments_attributes: [:id, :file, :_destroy],
+    )
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,7 +2,10 @@ class Assignment < ActiveRecord::Base
   belongs_to :outcome_coverage
 
   has_many :attachments, as: :attachable
-  accepts_nested_attributes_for :attachments
+
+  accepts_nested_attributes_for :attachments,
+    allow_destroy: true,
+    reject_if: :all_blank
 
   has_one :outcome, through: :outcome_coverage
 


### PR DESCRIPTION
This change brings assignment attachments into parity with coverage
attachments.