### PR TITLE
Run JavaScript feature specs in headless Chrome

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,17 @@
+require "selenium/webdriver"
+
 Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
-Capybara.javascript_driver = :chrome
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
Chrome 59 is now shipping, which supports headless operation. This PR
adds a new `headless_chrome` driver and sets Capybara to use it by
default for JavaScript specs. If it is useful during debugging to see
the tests function, you can change the driver to `chrome`.