### PR TITLE
User can archive an outcome coverage

### DIFF
--- a/app/controllers/manage_assessments/outcome_coverages_controller.rb
+++ b/app/controllers/manage_assessments/outcome_coverages_controller.rb
@@ -1,0 +1,12 @@
+module ManageAssessments
+  class OutcomeCoveragesController < ApplicationController
+    def destroy
+      outcome_coverage = OutcomeCoverage.find(params[:id])
+      authorize(outcome_coverage)
+
+      Archive.process(outcome_coverage: outcome_coverage)
+
+      redirect_to manage_assessments_course_path(outcome_coverage.coverage.course)
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,7 +1,7 @@
 class Course < ActiveRecord::Base
   belongs_to :department
 
-  has_many :coverages
+  has_many :coverages, -> { where archived: false }
   has_many :outcome_coverages, through: :coverages
   has_many :outcomes, -> { order(:label) }
   has_many :outcomes_with_metadata,

--- a/app/models/course_coverage.rb
+++ b/app/models/course_coverage.rb
@@ -1,6 +1,6 @@
 class CourseCoverage < SimpleDelegator
   def has_coverages?
-    coverages.present?
+    coverages.where(archived: false).present?
   end
 
   def covered_outcomes_count

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -2,7 +2,7 @@ class Coverage < ActiveRecord::Base
   belongs_to :course
   belongs_to :subject, required: true
 
-  has_many :outcome_coverages
+  has_many :outcome_coverages, -> { where archived: false }
   has_many :outcomes, through: :outcome_coverages
   has_many :attachments, as: :attachable
 
@@ -14,7 +14,7 @@ class Coverage < ActiveRecord::Base
     allow_destroy: true,
     reject_if: :all_blank
 
-  validates :subject_id, presence: true, uniqueness: { scope: :course_id }
+  validates :subject_id, presence: true, uniqueness: { scope: [:course_id, :archived] }, unless: :archived
   validate :must_have_outcomes
 
   private

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -6,5 +6,5 @@ class OutcomeCoverage < ActiveRecord::Base
 
   delegate :label, :nickname, to: :outcome, prefix: true
 
-  validates :outcome_id, uniqueness: { scope: :coverage_id }
+  validates :outcome_id, uniqueness: { scope: [:coverage_id, :archived] }, unless: :archived
 end

--- a/app/policies/outcome_coverage_policy.rb
+++ b/app/policies/outcome_coverage_policy.rb
@@ -1,0 +1,5 @@
+class OutcomeCoveragePolicy < ApplicationPolicy
+  def destroy?
+    user.manage_assessments?(record.coverage.course.department)
+  end
+end

--- a/app/services/archive.rb
+++ b/app/services/archive.rb
@@ -1,0 +1,32 @@
+class Archive
+  def self.process(outcome_coverage:)
+    new(outcome_coverage: outcome_coverage).process
+  end
+
+  def initialize(outcome_coverage:)
+    @outcome_coverage = outcome_coverage
+  end
+
+  def process
+    if coverage_has_more_than_one(outcome_coverage)
+      outcome_coverage.update!(archived: true)
+    else
+      archive_coverage_and(outcome_coverage)
+    end
+  end
+
+  private
+
+  attr_reader :outcome_coverage
+
+  def coverage_has_more_than_one(outcome_coverage)
+    outcome_coverage.coverage.outcomes.count > 1
+  end
+
+  def archive_coverage_and(outcome_coverage)
+    ActiveRecord::Base.transaction do
+      outcome_coverage.coverage.update!(archived: true)
+      outcome_coverage.update!(archived: true)
+    end
+  end
+end

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -27,5 +27,6 @@
       <%= outcome_coverage.outcome.description %>
     </p>
     <% end %>
+    <p> <%= link_to "Delete", manage_assessments_outcome_coverage_path(outcome_coverage), method: :delete %> </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
       resources :assignments, only: [:new, :create]
     end
 
+    resources :outcome_coverages, only: [:destroy]
+
     resources :assessments, only: [:new, :create, :edit, :update] do
       resource :archive, only: [:create, :destroy]
     end

--- a/db/migrate/20170605211925_add_archived_to_outcome_coverages.rb
+++ b/db/migrate/20170605211925_add_archived_to_outcome_coverages.rb
@@ -1,0 +1,5 @@
+class AddArchivedToOutcomeCoverages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :outcome_coverages, :archived, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20170606154105_add_archived_to_coverages.rb
+++ b/db/migrate/20170606154105_add_archived_to_coverages.rb
@@ -1,0 +1,5 @@
+class AddArchivedToCoverages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :coverages, :archived, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20170606164636_add_unique_index_on_archived_to_outcome_coverages.rb
+++ b/db/migrate/20170606164636_add_unique_index_on_archived_to_outcome_coverages.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexOnArchivedToOutcomeCoverages < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :outcome_coverages, [:coverage_id, :outcome_id]
+    add_index :outcome_coverages, [:coverage_id, :outcome_id], unique: true, where: "(archived is FALSE)"
+  end
+end

--- a/db/migrate/20170607151337_add_unique_index_on_archived_to_coverages.rb
+++ b/db/migrate/20170607151337_add_unique_index_on_archived_to_coverages.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexOnArchivedToCoverages < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :coverages, [:course_id, :subject_id]
+    add_index :coverages, [:course_id, :subject_id], unique: true, where: "(archived is FALSE)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170601183541) do
+ActiveRecord::Schema.define(version: 20170607151337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,7 +78,8 @@ ActiveRecord::Schema.define(version: 20170601183541) do
     t.datetime "updated_at", null: false
     t.integer "course_id", null: false
     t.integer "subject_id", null: false
-    t.index ["course_id", "subject_id"], name: "index_coverages_on_course_id_and_subject_id", unique: true
+    t.boolean "archived", default: false, null: false
+    t.index ["course_id", "subject_id"], name: "index_coverages_on_course_id_and_subject_id", unique: true, where: "(archived IS FALSE)"
     t.index ["subject_id"], name: "index_coverages_on_subject_id"
   end
 
@@ -106,7 +107,8 @@ ActiveRecord::Schema.define(version: 20170601183541) do
     t.datetime "updated_at", null: false
     t.integer "coverage_id", null: false
     t.integer "outcome_id", null: false
-    t.index ["coverage_id", "outcome_id"], name: "index_outcome_coverages_on_coverage_id_and_outcome_id", unique: true
+    t.boolean "archived", default: false, null: false
+    t.index ["coverage_id", "outcome_id"], name: "index_outcome_coverages_on_coverage_id_and_outcome_id", unique: true, where: "(archived IS FALSE)"
     t.index ["coverage_id"], name: "index_outcome_coverages_on_coverage_id"
     t.index ["outcome_id"], name: "index_outcome_coverages_on_outcome_id"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,6 +11,11 @@ FactoryGirl.define do
     standard_outcome
   end
 
+  factory :assignment do
+    sequence(:name) { |n| "Problem Set #{n}" }
+    sequence(:problem) { |n| "Question #{n}" }
+  end
+
   factory :course do
     name
     number

--- a/spec/features/user_deletes_outcome_coverage_from_a_subject_spec.rb
+++ b/spec/features/user_deletes_outcome_coverage_from_a_subject_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+feature "User deletes an outcome coverage for a subject" do
+  scenario "coverage has 2 or more outcome coverages" do
+    course = create(:course)
+    outcomes = create_pair(:outcome, course: course)
+    coverage = create(:coverage, course: course, outcomes: outcomes)
+    user = user_with_assessments_access_to(course.department)
+
+    visit manage_assessments_course_path(course.id, as: user)
+    first(".class-card-outcomes-wrapper").click_on("Delete")
+
+    expect(page).to have_outcome_number_of(1)
+  end
+
+  scenario "coverage has 1 outcome coverage with associated assignments" do
+    course = create(:course)
+    outcome = create(:outcome, course: course)
+    coverage = create(:coverage, course: course, outcomes: [outcome])
+    outcome_coverage = OutcomeCoverage.first
+    user = user_with_assessments_access_to(course.department)
+    assignment = create(:assignment, outcome_coverage: outcome_coverage)
+    coverage.outcome_coverages.first.update(assignment: assignment)
+
+    visit manage_assessments_course_path(course.id, as: user)
+    click_on "Delete"
+
+    expect(page).to have_content(course.number)
+    expect(page).to have_content t("manage_assessments.courses.show_without_coverages.no_classes", name: course.name)
+    expect(page).to have_no_content(coverage.subject.title)
+    expect(page).to have_no_content(outcome.nickname)
+  end
+
+  def have_outcome_number_of(count)
+    have_css(".class-card-outcomes-wrapper", count: count)
+  end
+end

--- a/spec/models/coverage_spec.rb
+++ b/spec/models/coverage_spec.rb
@@ -7,6 +7,6 @@ describe Coverage do
     create(:coverage, course: course, outcomes: [outcome])
     coverage = Coverage.new
 
-    expect(coverage).to validate_uniqueness_of(:subject_id).scoped_to(:course_id)
+    expect(coverage).to validate_uniqueness_of(:subject_id).scoped_to(:course_id, :archived)
   end
 end

--- a/spec/models/outcome_coverage_spec.rb
+++ b/spec/models/outcome_coverage_spec.rb
@@ -7,6 +7,6 @@ describe OutcomeCoverage do
     coverage = create(:coverage, course: course, outcomes: [outcome])
     outcome_coverage = OutcomeCoverage.new(coverage: coverage, outcome: outcome)
 
-    expect(outcome_coverage).to validate_uniqueness_of(:outcome_id).scoped_to(:coverage_id)
+    expect(outcome_coverage).to validate_uniqueness_of(:outcome_id).scoped_to(:coverage_id, :archived)
   end
 end


### PR DESCRIPTION
When a user clicks Delete, the selected outcome coverage is archived. If a coverage only has one outcome coverage, the coverage and the outcome coverage are archived and no longer displayed on the UI. To accomplish this, an archived boolean column was added to both the `Outcome Coverages` and `Coverages` table. An `Archive` service object handles the archiving of objects. 