### PR TITLE
User can download an attachment

### DIFF
--- a/app/controllers/manage_assessments/attachments_controller.rb
+++ b/app/controllers/manage_assessments/attachments_controller.rb
@@ -1,0 +1,10 @@
+module ManageAssessments
+  class AttachmentsController < ApplicationController
+    def show
+      @attachment = Attachment.find(params[:id])
+      authorize(@attachment)
+
+      redirect_to @attachment.expiring_url
+    end
+  end
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,4 +1,6 @@
 class Attachment < ActiveRecord::Base
+  EXPIRE_TIMEFRAME = 60.seconds
+
   belongs_to :attachable, polymorphic: true
 
   has_attached_file :file,
@@ -10,5 +12,17 @@ class Attachment < ActiveRecord::Base
 
   def name
     file_file_name
+  end
+
+  def expiring_url
+    file.expiring_url(Time.now + EXPIRE_TIMEFRAME)
+  end
+
+  def course_department
+    attachable.course_department
+  end
+
+  def subject_department
+    attachable.subject_department
   end
 end

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -1,0 +1,5 @@
+class AttachmentPolicy < ApplicationPolicy
+  def show?
+    user.manage_assessments?(record.course_department)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
 
     resources :outcome_coverages, only: [:destroy]
 
+    resources :attachments, only: [:show]
+
     resources :assessments, only: [:new, :create, :edit, :update] do
       resource :archive, only: [:create, :destroy]
     end

--- a/spec/controllers/manage_assessments/attachments_controller_spec.rb
+++ b/spec/controllers/manage_assessments/attachments_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe ManageAssessments::AttachmentsController do
+  describe "GET #show" do
+    it "downloads the requested attachment from server" do
+      assignment = create(:assignment)
+      attachment = create(:attachment, attachable: assignment)
+      department = assignment.course_department
+      user = user_with_assessments_access_to(department)
+
+      sign_in(user)
+      get :show, params: { id: attachment.id }
+
+      expect(response).to redirect_to(attachment.expiring_url)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,6 +23,17 @@ FactoryGirl.define do
     end
   end
 
+  factory :attachment do
+    file File.open("spec/fixtures/attachments/example.pdf")
+
+    after(:build) do |attachment|
+      if attachment.attachable.nil?
+        assignment = create(:assignment)
+        attachment.attachable = assignment
+      end
+    end
+  end
+
   factory :course do
     name
     number


### PR DESCRIPTION
A user can download an attachment from S3 from an expiring url. This url is not available to the general public. This functionality was accomplished by using Paperclip's [restricting access to objects on S3 features](https://github.com/thoughtbot/paperclip/wiki/Restricting-Access-to-Objects-Stored-on-Amazon-S3).  This branch also adds an attachment factory. 