### PR TITLE
Make recent migrations work against production

### DIFF
--- a/db/migrate/20170508192308_update_outcomes_with_metadata_to_version_2.rb
+++ b/db/migrate/20170508192308_update_outcomes_with_metadata_to_version_2.rb
@@ -1,4 +1,4 @@
-class UpdateOutcomesWithMetadataToVersion2 < ActiveRecord::Migration
+class UpdateOutcomesWithMetadataToVersion2 < ActiveRecord::Migration[5.0]
   def change
     update_view :outcomes_with_metadata, version: 2, revert_to_version: 1
   end

--- a/db/migrate/20170508193058_remove_indirect_assessments.rb
+++ b/db/migrate/20170508193058_remove_indirect_assessments.rb
@@ -2,6 +2,8 @@ class RemoveIndirectAssessments < ActiveRecord::Migration[5.0]
   def up
     drop_table :indirect_assessments
 
+    execute "DELETE FROM outcome_assessments WHERE assessment_type = 'IndirectAssessment'"
+
     remove_column :outcome_assessments, :assessment_type
     add_index :outcome_assessments, :assessment_id
     add_foreign_key :outcome_assessments, :direct_assessments, column: :assessment_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "alignments", force: :cascade do |t|
+  create_table "alignments", id: :serial, force: :cascade do |t|
     t.integer "outcome_id", null: false
     t.integer "standard_outcome_id", null: false
     t.string "level", null: false
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["standard_outcome_id"], name: "index_alignments_on_standard_outcome_id"
   end
 
-  create_table "assessments", force: :cascade do |t|
+  create_table "assessments", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "description", null: false
     t.string "problem_description"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["subject_id"], name: "index_assessments_on_subject_id"
   end
 
-  create_table "assignments", force: :cascade do |t|
+  create_table "assignments", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "outcome_coverage_id", null: false
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["outcome_coverage_id"], name: "index_assignments_on_outcome_coverage_id"
   end
 
-  create_table "attachments", force: :cascade do |t|
+  create_table "attachments", id: :serial, force: :cascade do |t|
     t.string "file_file_name", null: false
     t.string "file_content_type", null: false
     t.integer "file_file_size", null: false
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["attachable_type", "attachable_id"], name: "index_attachments_on_attachable_type_and_attachable_id"
   end
 
-  create_table "courses", force: :cascade do |t|
+  create_table "courses", id: :serial, force: :cascade do |t|
     t.string "number", null: false
     t.string "name", null: false
     t.integer "department_id", null: false
@@ -69,11 +69,10 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "outcomes_count", default: 0, null: false
-    t.index ["department_id"], name: "index_courses_on_department_id"
     t.index ["number"], name: "index_courses_on_number", unique: true
   end
 
-  create_table "coverages", force: :cascade do |t|
+  create_table "coverages", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id", null: false
@@ -83,7 +82,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["subject_id"], name: "index_coverages_on_subject_id"
   end
 
-  create_table "departments", force: :cascade do |t|
+  create_table "departments", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.datetime "created_at", null: false
@@ -93,7 +92,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["slug"], name: "index_departments_on_slug", unique: true
   end
 
-  create_table "outcome_assessments", force: :cascade do |t|
+  create_table "outcome_assessments", id: :serial, force: :cascade do |t|
     t.integer "outcome_id", null: false
     t.integer "assessment_id", null: false
     t.datetime "created_at", null: false
@@ -102,7 +101,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["outcome_id"], name: "index_outcome_assessments_on_outcome_id"
   end
 
-  create_table "outcome_coverages", force: :cascade do |t|
+  create_table "outcome_coverages", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "coverage_id", null: false
@@ -113,7 +112,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["outcome_id"], name: "index_outcome_coverages_on_outcome_id"
   end
 
-  create_table "outcomes", force: :cascade do |t|
+  create_table "outcomes", id: :serial, force: :cascade do |t|
     t.string "label", limit: 5, null: false
     t.string "description", null: false
     t.integer "course_id", null: false
@@ -125,7 +124,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["course_id", "nickname"], name: "index_outcomes_on_course_id_and_nickname", unique: true
   end
 
-  create_table "results", force: :cascade do |t|
+  create_table "results", id: :serial, force: :cascade do |t|
     t.integer "assessment_id"
     t.string "assessment_name"
     t.string "assessment_description"
@@ -142,7 +141,7 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["assignment_id"], name: "index_results_on_assignment_id"
   end
 
-  create_table "standard_outcomes", force: :cascade do |t|
+  create_table "standard_outcomes", id: :serial, force: :cascade do |t|
     t.string "label", limit: 5, null: false
     t.string "description", null: false
     t.datetime "created_at", null: false
@@ -151,21 +150,21 @@ ActiveRecord::Schema.define(version: 20170607193812) do
     t.index ["nickname"], name: "index_standard_outcomes_on_nickname", unique: true
   end
 
-  create_table "subjects", force: :cascade do |t|
+  create_table "subjects", id: :serial, force: :cascade do |t|
     t.string "number", null: false
     t.string "title", null: false
     t.integer "department_number", null: false
     t.index ["department_number"], name: "index_subjects_on_department_number"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  create_table "versions", force: :cascade do |t|
+  create_table "versions", id: :serial, force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
@@ -186,7 +185,6 @@ ActiveRecord::Schema.define(version: 20170607193812) do
   add_foreign_key "outcome_assessments", "assessments"
   add_foreign_key "outcome_coverages", "coverages", on_delete: :cascade
   add_foreign_key "outcome_coverages", "outcomes"
-  add_foreign_key "outcomes", "courses"
   add_foreign_key "results", "assessments"
   add_foreign_key "results", "assignments"
 


### PR DESCRIPTION
We had not been running these migrations against production data. Doing
so highlighted a couple of issues. The biggest was that we have some
`outcome_assessment` records that reference now-deleted
`IndirectAssessment` records. We checked with Jon, who said it was okay
to delete these. In this case, it's okay to edit past migrations because
they have not been deployed and run yet.

The `create_table` statements in `schema.rb` also changed to indicate
that the `id` column is of type `:serial`. This appears to be
ActiveRecord 5.1 being more explicit than it had been previously. The
underlying table definition is unchanged. See:
https://github.com/rails/rails/blob/c6b4b4a52c7ec66d1923ef44dcbc71b582d7b165/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb#L49-L53