### PR TITLE
Add task to migrate assessments to assignments

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20170612182739) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "department_id"
-    t.integer "assignment_id"
+    t.bigint "assignment_id"
     t.index ["assessment_id", "year", "semester"], name: "index_results_on_assessment_id_and_year_and_semester", unique: true
     t.index ["assignment_id", "year", "semester"], name: "index_results_on_assignment_id_and_year_and_semester", unique: true
     t.index ["assignment_id"], name: "index_results_on_assignment_id"

--- a/lib/tasks/assessments.rake
+++ b/lib/tasks/assessments.rake
@@ -1,0 +1,34 @@
+namespace :assessments do
+  desc "Migrate assessments to assignments"
+  task migrate: :environment do
+    ActiveRecord::Base.transaction do
+      Assessment.find_each do |assessment|
+        puts "Migrating assessment: #{assessment.id}"
+
+        coverage = Coverage.find_or_initialize_by(
+          course_id: assessment.courses.first.id,
+          subject_id: assessment.subject_id
+        )
+
+        coverage.outcomes << (assessment.outcomes - coverage.outcomes)
+        coverage.save!
+
+        coverage.outcome_coverages.each do |outcome_coverage|
+          assignment = Assignment.create!(
+            name: assessment.name,
+            problem: assessment.problem_description,
+            outcome_coverage_id: outcome_coverage.id,
+          )
+
+          assessment.results.update_all(assignment_id: assignment.id)
+        end
+      end
+
+      Coverage.includes(:outcome_coverages).find_each do |coverage|
+        if coverage.outcome_coverages.all?(&:archived?)
+          coverage.update(archived: true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is quite the brute-force approach, but this task will be run once
in production and then never again. Once its run in production, we can
remove this task entirely and clean up the now-migrated data, tables,
etc.