### PR TITLE
Don't create duplicate assignments when migrating

### DIFF
--- a/lib/tasks/assessments.rake
+++ b/lib/tasks/assessments.rake
@@ -2,33 +2,83 @@ namespace :assessments do
   desc "Migrate assessments to assignments"
   task migrate: :environment do
     ActiveRecord::Base.transaction do
-      Assessment.find_each do |assessment|
-        puts "Migrating assessment: #{assessment.id}"
+      Assessment.includes(:outcomes, :courses).find_each do |assessment|
+        MigrateAssessment.call(assessment)
+      end
+    end
+  end
 
-        coverage = Coverage.find_or_initialize_by(
-          course_id: assessment.courses.first.id,
-          subject_id: assessment.subject_id
+  class MigrateAssessment
+    def self.call(assessment)
+      new(assessment).call
+    end
+
+    def initialize(assessment)
+      @assessment = assessment
+      @coverage = Coverage.find_or_initialize_by(
+        course_id: assessment.course_ids.first,
+        subject_id: assessment.subject_id,
+      )
+    end
+
+    def call
+      coverage.save!(validate: false)
+      add_outcomes_to_coverage
+    end
+
+    private
+
+    attr_reader :assessment, :coverage
+
+    def add_outcomes_to_coverage
+      AddOutcomes.call(from: assessment, to: coverage)
+    end
+  end
+
+  class AddOutcomes
+    def self.call(from:, to:)
+      new(from: from, to: to).call
+    end
+
+    def initialize(from:, to:)
+      @assessment = from
+      @coverage = to
+    end
+
+    def call
+      assessment.outcomes.each do |outcome|
+        outcome_coverage = add_outcome_coverage(outcome)
+        assignment = outcome_coverage.create_assignment(
+          name: assessment.name,
+          problem: assessment.problem_description,
         )
 
-        coverage.outcomes << (assessment.outcomes - coverage.outcomes)
-        coverage.save!
-
-        coverage.outcome_coverages.each do |outcome_coverage|
-          assignment = Assignment.create!(
-            name: assessment.name,
-            problem: assessment.problem_description,
-            outcome_coverage_id: outcome_coverage.id,
-          )
-
-          assessment.results.update_all(assignment_id: assignment.id)
-        end
+        assessment.results.update_all(assignment_id: assignment.id)
       end
+    end
 
-      Coverage.includes(:outcome_coverages).find_each do |coverage|
-        if coverage.outcome_coverages.all?(&:archived?)
-          coverage.update(archived: true)
-        end
-      end
+    private
+
+    attr_reader :assessment, :coverage
+
+    def add_outcome_coverage(outcome)
+      coverage.outcome_coverages.create!(
+        outcome_id: outcome.id,
+        archived: assessment.archived? || should_be_archived?(outcome)
+      )
+    end
+
+    def should_be_archived?(outcome)
+      most_recently_active = Assessment.
+        joins(:outcomes).
+        where(archived: false).
+        where(subject_id: assessment.subject_id).
+        where(outcomes: { id: outcome.id }).
+        order(results_count: :desc).
+        order(created_at: :desc).
+        first
+
+      most_recently_active != assessment
     end
   end
 end


### PR DESCRIPTION
The previous version of the assessment migration task was creating
duplicate assignments because it was creating the same assignment for
every outcome on the assessment.

Fixing this revealed an incompatibility in the data model between
assessments and coverages/assignments. With assessments, users could
create multiple assessments in the same subject that covered the same
outcome. With the change to coverages and assignments, we ask the users
to provide the assignment that *best* covers an outcome in the given
subject. We have validations and database constraints that prevent
covering the same outcome more than once in a subject.

As a result, when migrating assessments to outcome coverages, we mark
the outcome coverage associated with all but the most recently active
(most results, most recently created) assessment as archived.