### PR TITLE
Order course outcomes in the controller

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,7 +3,7 @@ class Course < ActiveRecord::Base
 
   has_many :coverages, -> { where archived: false }
   has_many :outcome_coverages, through: :coverages
-  has_many :outcomes, -> { order(:label) }
+  has_many :outcomes
 
   def self.without_outcomes
     where(outcomes_count: 0)

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -21,6 +21,10 @@ class Outcome < ActiveRecord::Base
 
   has_paper_trail
 
+  def self.alphabetical
+    order(:label)
+  end
+
   def to_s
     "#{label} - #{description}"
   end

--- a/app/views/manage_outcomes/outcomes/_outcomes.html.erb
+++ b/app/views/manage_outcomes/outcomes/_outcomes.html.erb
@@ -6,7 +6,7 @@
     </tr>
   </thead>
   <tbody>
-    <% course.outcomes.each do |outcome| %>
+    <% course.outcomes.alphabetical.each do |outcome| %>
       <tr>
         <td>
           <p><%= outcome.nickname %></p>


### PR DESCRIPTION
This branch uses a method on the Outcome class to order outcomes by label name, instead of ordering them via the `has_many outcomes` relation on the Course model.