### PR TITLE
Don't use instance variables in partials

### DIFF
--- a/app/views/manage_assessments/courses/_outcome_status.html.erb
+++ b/app/views/manage_assessments/courses/_outcome_status.html.erb
@@ -1,4 +1,4 @@
-<%= link_to new_manage_assessments_course_coverage_path(@course, outcome_id: outcome.id), class: "outcome-card #{outcome_card_class(outcome)}" do %>
+<%= link_to new_manage_assessments_course_coverage_path(outcome.course_id, outcome_id: outcome.id), class: "outcome-card #{outcome_card_class(outcome)}" do %>
   <div class="outcome-card-copy">
     <h3 class="outcome-letter-subhead"><%= t(".label", label: outcome.label) %></h3>
     <h2 class="outcome-nickname"><%= outcome.nickname %></h2>

--- a/app/views/manage_assessments/coverages/_form.html.erb
+++ b/app/views/manage_assessments/coverages/_form.html.erb
@@ -4,7 +4,7 @@
 
 <%= form.simple_fields_for :outcome_coverages do |outcome_coverage_fields| %>
   <%= outcome_coverage_fields.input :outcome_id,
-    collection: @coverage.course.outcomes,
+    collection: form.object.course.outcomes,
     label_method: :to_short_s,
     required: outcome_coverage_fields.options[:child_index] == 0 %>
 <% end %>
@@ -13,7 +13,7 @@
   <%= link_to_add_association t(".add_outcome"),
     form,
     :outcome_coverages,
-    render_options: { locals: { outcomes: @coverage.course.outcomes } } %>
+    render_options: { locals: { outcomes: form.object.course.outcomes } } %>
 </div>
 
 <%= render "attachments/nested_form", form: form %>


### PR DESCRIPTION
These can sneak in when we extract partials, but we should instead be
relying on local variables. Partials that use local variables are easier
to reuse as they don't rely on pre-existing instance state. They're also
easier to maintain as changing the name of an instance variable in a
controller doesn't cause downstream partials to break unnecessarily.