### PR TITLE
Add additional activities to the Activity Feed

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,6 +1,6 @@
 class ActivitiesController < ApplicationController
   def index
-    activities = policy_scope(Activity.includes(:user, :result).limit(100))
+    activities = policy_scope(Activity.includes(:user, :item).limit(100))
     @activity_feed = ActivityFeed.new(activities)
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,17 +1,11 @@
-class Activity < PaperTrail::Version
-  default_scope { where(item_type: "Result") }
-
-  belongs_to :user, foreign_key: :whodunnit
-  belongs_to :result, foreign_key: :item_id
+class Activity < ApplicationRecord
+  belongs_to :user
+  belongs_to :item, polymorphic: true
 
   delegate :username, to: :user, allow_nil: true
 
   def date
     created_at.to_date
-  end
-
-  def subject
-    result.assignment.subject.to_s
   end
 
   def time_formatted

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -18,4 +18,10 @@ class Assignment < ActiveRecord::Base
   delegate :department, to: :course, prefix: true
 
   validates :name, presence: true
+
+  has_paper_trail
+
+  def subject_name
+    subject.to_s
+  end
 end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -7,4 +7,10 @@ class OutcomeCoverage < ActiveRecord::Base
   delegate :label, :nickname, to: :outcome, prefix: true
 
   validates :outcome_id, uniqueness: { scope: [:coverage_id, :archived] }, unless: :archived
+
+  has_paper_trail
+
+  def subject_name
+    coverage.subject.to_s
+  end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -23,6 +23,10 @@ class Result < ActiveRecord::Base
     "#{assessment_name} - #{assessment_description}"
   end
 
+  def subject_name
+    assignment.subject.to_s
+  end
+
   private
 
   def denormalize_department

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -2,8 +2,7 @@ class ActivityPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       scope.
-        joins(result: :department).
-        where(departments: { slug: user.department_slugs }).
+        where(department_id: user.departments.pluck(:id)).
         order(created_at: :desc)
     end
   end

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -9,16 +9,8 @@
 
   <td class="activity-event-and-subject">
     <span class="activity-event">
-      <%= t(
-        ".event.#{activity.event}_html",
-        assignment: link_to(
-          activity.result.name,
-          manage_results_assignment_path(activity.result.assignment_id)
-        ),
-      ) %>
+      <%= render "#{activity.item_type.underscore}_activity", activity: activity %>
     </span>
-
-    <span class="activity-subject"><%= activity.subject %></span>
   </td>
 
   <td class="activity-user">

--- a/app/views/activities/_assignment_activity.html.erb
+++ b/app/views/activities/_assignment_activity.html.erb
@@ -1,0 +1,6 @@
+<%= t(".event.#{activity.event}_#{activity.item_type.downcase}_html",
+    name: link_to(
+      activity.item.name,
+      manage_assessments_course_path(activity.item.course)
+    ),
+    subject: activity.item.subject_name) %>

--- a/app/views/activities/_outcome_coverage_activity.html.erb
+++ b/app/views/activities/_outcome_coverage_activity.html.erb
@@ -1,0 +1,2 @@
+<%= t(".event.#{activity.event}_#{activity.item_type.downcase}_html",
+    subject: activity.item.subject_name) %>

--- a/app/views/activities/_result_activity.html.erb
+++ b/app/views/activities/_result_activity.html.erb
@@ -1,0 +1,8 @@
+<%= t(
+    ".event.#{activity.event}_#{activity.item_type.downcase}_html",
+    assignment: link_to(
+      activity.item.assignment.name,
+      manage_results_assignment_path(activity.item.assignment_id)
+    ),
+    subject: activity.item.subject_name
+) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,10 +36,18 @@ en:
     models:
       direct_assessment: Direct Assessment
   activities:
-    activity:
+    assignment_activity:
       event:
-        create_html: Results created for %{assignment}
-        update_html: Results updated for %{assignment}
+        create_assignment_html: Assignment %{name} created for %{subject}
+        update_assignment_html: Assignment %{name} updated for %{subject}
+    outcome_coverage_activity:
+      event:
+        create_outcomecoverage_html: Outcome coverage created for %{subject}
+        update_outcomecoverage_html: Outcome coverage updated for %{subject}
+    result_activity:
+      event:
+        create_result_html: Result created for %{assignment} in %{subject}
+        update_result_html: Result updated for %{assignment} in %{subject}
     index:
       activity_count:
         one: 1 Change

--- a/db/migrate/20170620185115_create_activities.rb
+++ b/db/migrate/20170620185115_create_activities.rb
@@ -1,0 +1,5 @@
+class CreateActivities < ActiveRecord::Migration[5.0]
+  def change
+    create_view :activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170614152932) do
+ActiveRecord::Schema.define(version: 20170620185115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -210,6 +210,49 @@ ActiveRecord::Schema.define(version: 20170614152932) do
        JOIN subjects ON ((subjects.id = coverages.subject_id)))
        JOIN outcomes ON ((outcomes.id = outcome_coverages.outcome_id)))
     ORDER BY outcomes.label, results.year DESC, results.semester DESC;
+  SQL
+
+  create_view "activities",  sql_definition: <<-SQL
+      SELECT versions.id,
+      versions.item_type,
+      versions.item_id,
+      versions.event,
+      versions.whodunnit AS user_id,
+      departments.id AS department_id,
+      versions.created_at
+     FROM ((versions
+       JOIN results ON ((versions.item_id = results.id)))
+       JOIN departments ON ((results.department_id = departments.id)))
+    WHERE ((versions.item_type)::text = 'Result'::text)
+  UNION ALL
+   SELECT versions.id,
+      versions.item_type,
+      versions.item_id,
+      versions.event,
+      versions.whodunnit AS user_id,
+      departments.id AS department_id,
+      versions.created_at
+     FROM (((((versions
+       JOIN assignments ON ((versions.item_id = assignments.id)))
+       JOIN outcome_coverages ON ((assignments.outcome_coverage_id = outcome_coverages.id)))
+       JOIN coverages ON ((outcome_coverages.coverage_id = coverages.id)))
+       JOIN courses ON ((coverages.course_id = courses.id)))
+       JOIN departments ON ((courses.department_id = departments.id)))
+    WHERE ((versions.item_type)::text = 'Assignment'::text)
+  UNION ALL
+   SELECT versions.id,
+      versions.item_type,
+      versions.item_id,
+      versions.event,
+      versions.whodunnit AS user_id,
+      departments.id AS department_id,
+      versions.created_at
+     FROM ((((versions
+       JOIN outcome_coverages ON ((versions.item_id = outcome_coverages.id)))
+       JOIN coverages ON ((outcome_coverages.coverage_id = coverages.id)))
+       JOIN courses ON ((coverages.course_id = courses.id)))
+       JOIN departments ON ((courses.department_id = departments.id)))
+    WHERE ((versions.item_type)::text = 'OutcomeCoverage'::text);
   SQL
 
 end

--- a/db/views/activities_v01.sql
+++ b/db/views/activities_v01.sql
@@ -1,0 +1,47 @@
+SELECT
+  versions.id as id,
+  versions.item_type as item_type,
+  versions.item_id as item_id,
+  versions.event as event,
+  versions.whodunnit as user_id,
+  departments.id as department_id,
+  versions.created_at as created_at
+FROM versions
+INNER JOIN results on versions.item_id = results.id
+INNER JOIN departments on results.department_id = departments.id
+WHERE item_type = 'Result'
+
+UNION ALL
+
+SELECT
+  versions.id as id,
+  versions.item_type as item_type,
+  versions.item_id as item_id,
+  versions.event as event,
+  versions.whodunnit as user_id,
+  departments.id as department_id,
+  versions.created_at as created_at
+FROM versions
+INNER JOIN assignments on versions.item_id = assignments.id
+INNER JOIN outcome_coverages on assignments.outcome_coverage_id = outcome_coverages.id
+INNER JOIN coverages on outcome_coverages.coverage_id = coverages.id
+INNER JOIN courses on coverages.course_id = courses.id
+INNER JOIN departments on courses.department_id = departments.id
+WHERE item_type = 'Assignment'
+
+UNION ALL
+
+SELECT
+  versions.id as id,
+  versions.item_type as item_type,
+  versions.item_id as item_id,
+  versions.event as event,
+  versions.whodunnit as user_id,
+  departments.id as department_id,
+  versions.created_at as created_at
+FROM versions
+INNER JOIN outcome_coverages on versions.item_id = outcome_coverages.id
+INNER JOIN coverages on outcome_coverages.coverage_id = coverages.id
+INNER JOIN courses on coverages.course_id = courses.id
+INNER JOIN departments on courses.department_id = departments.id
+WHERE item_type = 'OutcomeCoverage';

--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -10,13 +10,28 @@ feature "User views activity feed" do
   end
 
   scenario "sees recent results they have access to" do
-    result = create(:result)
-    result.update!(percentage: 99)
-    user = user_with_read_access_to(result.department)
+    course = create(:course)
+    subject = create(:subject, department: course.department)
+    outcome = create(:outcome, course: course)
+    coverage = create(:coverage, outcomes: [outcome], course: course, subject: subject)
+    assignment = create(:assignment, outcome_coverage: coverage.outcome_coverages.first)
+    result = create(:result, assignment: assignment)
+    result.update(percentage: 50)
+    other_department_result = create(:result)
+    user = user_with_read_access_to(course.department)
 
     visit activities_path(as: user)
 
-    expect(page).to have_content "Results created for #{result.name}"
-    expect(page).to have_content "Results updated for #{result.name}"
+    expect(page).to have_content t("activities.outcome_coverage_activity.event.create_outcomecoverage_html",
+                                    subject: subject)
+    expect(page).to have_content t("activities.assignment_activity.event.create_assignment_html",
+                                    name: assignment.name,
+                                    subject: subject)
+    expect(page).to have_content t("activities.result_activity.event.update_result_html",
+                                    assignment: assignment.name,
+                                    subject: subject)
+    expect(page).to have_no_content t("activities.result_activity.event.create_result_html",
+                                    assignment: other_department_result.assignment.name,
+                                    subject: other_department_result.assignment.subject)
   end
 end


### PR DESCRIPTION
This branch adds paper_trail ([documentation here](https://github.com/airblade/paper_trail)) to assignments and outcome coverages. The activity feed now displays when the following have been created or updated: 
* Results
* Assignments
* Outcome Coverages

Clicking the link associated with a result directs the user to the `manage_results_assignment_path`, where the user can view and edit the result. Clicking the link associated with an assignment directs the user to the corresponding course page (`manage_assessments_course_path`) for that assignment. 

![activity_feed1](https://user-images.githubusercontent.com/9501674/27294383-6770af26-54e7-11e7-9dcc-e63b436f857b.png)
