### PR TITLE
Update deployment script

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,5 +10,5 @@ server "outcomes",
 set :rvm_type, :system
 set :rvm_ruby_version, "2.2.2"
 set :deploy_to, "/var/www/outcomes"
-set :linked_files, fetch(:linked_files, []).push("config/database.yml")
+set :linked_files, fetch(:linked_files, []).push("config/database.yml", "config/secrets.yml.key")
 set :linked_dirs, fetch(:linked_dirs, []).push("config/certs")


### PR DESCRIPTION
When deploying to production, we need to symlink the `secrets.yml.key`
file, which is the private key for decrypting `secrets.yml.enc`. The key
file has already been deployed to the shared directory of the server.