### PR TITLE
Allow users to undo dynamic "add outcome"

### DIFF
--- a/app/controllers/manage_assessments/coverages_controller.rb
+++ b/app/controllers/manage_assessments/coverages_controller.rb
@@ -45,7 +45,7 @@ module ManageAssessments
         permit(
           :subject_id,
           attachments_attributes: [:id, :file, :_destroy],
-          outcome_coverages_attributes: [:id, :outcome_id],
+          outcome_coverages_attributes: [:id, :outcome_id, :_destroy]
         )
     end
   end

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -2,12 +2,12 @@ class Coverage < ActiveRecord::Base
   belongs_to :course
   belongs_to :subject, required: true
 
+  has_one :department, through: :course
   has_many :outcome_coverages, -> { where archived: false }
   has_many :outcomes, through: :outcome_coverages
   has_many :attachments, as: :attachable
 
   accepts_nested_attributes_for :outcome_coverages,
-    allow_destroy: true,
     reject_if: :all_blank
 
   accepts_nested_attributes_for :attachments,

--- a/app/views/manage_assessments/coverages/_outcome_coverage_fields.html.erb
+++ b/app/views/manage_assessments/coverages/_outcome_coverage_fields.html.erb
@@ -1,5 +1,11 @@
-<%= f.input :outcome_id,
-  headline: "and",
-  collection: outcomes,
-  label_method: :to_short_s,
-  required: false %>
+<div class="nested-fields">
+  <%= f.input :outcome_id,
+    headline: "and",
+    collection: outcomes,
+    label_method: :to_short_s,
+    required: false %>
+
+  <% if f.object.new_record? %>
+    <%= link_to_remove_association t(".remove"), f %>
+  <% end %>
+</div>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -46,10 +46,12 @@ en:
         add: Add
         headline: Add assignment
     coverages:
-      form:
-        add_outcome: Add Outcome
       coverage:
         add_another_outcome: Add an outcome
+      form:
+        add_outcome: Add Outcome
+      outcome_coverage_fields:
+        remove: undo
     outcome_coverages:
       outcome_coverage:
         add_assignment: Add an Assignment

--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -35,12 +35,6 @@ feature "user adds coverage to a course" do
     expect(page).to have_prepopulated_select_box(unmatched_outcome.nickname)
   end
 
-  def selectize(item, from:)
-    container = find_field(from, visible: false).first(:xpath, ".//..")
-    container.find(".selectize-control").click
-    container.find("div.option", text: item).click
-  end
-
   def have_prepopulated_select_box(text)
     have_css("select", text: text)
   end

--- a/spec/features/user_edits_course_coverage_spec.rb
+++ b/spec/features/user_edits_course_coverage_spec.rb
@@ -14,6 +14,20 @@ feature "User edits course coverage" do
     expect(page).to have_prepopulated_select_box(coverage.subject.title)
   end
 
+  scenario "by removing an unpersisted outcome", js: true do
+    coverage = create(:coverage)
+    outcome = create(:outcome, course: coverage.course)
+    user = user_with_assessments_access_to(coverage.department)
+
+    visit manage_assessments_course_path(coverage.course, as: user)
+    click_on t("manage_assessments.coverages.coverage.add_another_outcome")
+    click_on t("manage_assessments.coverages.form.add_outcome")
+    selectize outcome.nickname, from: "Outcome"
+    click_on t("manage_assessments.coverages.outcome_coverage_fields.remove")
+
+    expect(page).not_to have_content(outcome.nickname)
+  end
+
   def have_prepopulated_select_box(text)
     have_css("select", text: text)
   end

--- a/spec/support/selectize.rb
+++ b/spec/support/selectize.rb
@@ -1,0 +1,11 @@
+module SelectizeHelper
+  def selectize(item, from:)
+    container = find_field(from, visible: false).first(:xpath, ".//..")
+    container.find(".selectize-control").click
+    container.find("div.option", text: item).click
+  end
+end
+
+RSpec.configure do |config|
+  config.include SelectizeHelper, type: :feature
+end


### PR DESCRIPTION
When adding outcomes to a subject, users can click "Add outcome" to add
another outcome. If they decide against doing this, they can now click
"undo" to remove the dynamically added form fields for this.

The "undo" link is only shown for freshly-added inputs. You cannot
remove or delete an existing outcome from a subject. Instead, you can
archive it, which is accomplished from the list of subjects.