### PR TITLE
User can edit an assignment

### DIFF
--- a/app/controllers/manage_assessments/assignments_controller.rb
+++ b/app/controllers/manage_assessments/assignments_controller.rb
@@ -4,6 +4,11 @@ class ManageAssessments::AssignmentsController < ApplicationController
     authorize(@assignment)
   end
 
+  def edit
+    @assignment = OutcomeCoverage.find(params[:outcome_coverage_id]).assignment
+    authorize(@assignment)
+  end
+
   def create
     @assignment = outcome_coverage.build_assignment(assignment_params)
     authorize(@assignment)
@@ -13,6 +18,17 @@ class ManageAssessments::AssignmentsController < ApplicationController
         success: t(".success", label: outcome_coverage.outcome.label)
     else
       render :new
+    end
+  end
+
+  def update
+    @assignment = OutcomeCoverage.find(params[:outcome_coverage_id]).assignment
+    authorize(@assignment)
+
+    if @assignment.update_attributes(assignment_params)
+      redirect_to manage_assessments_course_path(@assignment.course)
+    else
+      render :edit
     end
   end
 

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -3,6 +3,14 @@ class AssignmentPolicy < ApplicationPolicy
     user.manage_assessments?(record.coverage.course.department)
   end
 
+  def edit?
+    create?
+  end
+
+  def update?
+    edit?
+  end 
+
   def create_results?
     ResultPolicy.new(user, Result.new(assignment: record)).create?
   end

--- a/app/views/manage_assessments/assignments/_form.html.erb
+++ b/app/views/manage_assessments/assignments/_form.html.erb
@@ -1,0 +1,5 @@
+<%= form.input :name %>
+<%= form.input :problem %>
+
+<%= render "attachments/nested_form", form: form %>
+<%= render "manage_assessments/madlib_controls", form: form %>

--- a/app/views/manage_assessments/assignments/edit.html.erb
+++ b/app/views/manage_assessments/assignments/edit.html.erb
@@ -11,6 +11,6 @@
   </div>
 <% end %>
 
-<%= madlib_form_for @assignment, url: manage_assessments_outcome_coverage_assignments_path do |form| %>
+<%= madlib_form_for @assignment, url: manage_assessments_outcome_coverage_assignment_path do |form| %>
   <%= render "form", form: form %>
 <% end %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -27,6 +27,10 @@
       <%= outcome_coverage.outcome.description %>
     </p>
     <% end %>
-    <p> <%= link_to "Delete", manage_assessments_outcome_coverage_path(outcome_coverage), method: :delete %> </p>
+    <p> <%= link_to t(".edit_assignment"),
+            edit_manage_assessments_outcome_coverage_assignment_path(
+              outcome_coverage_id: outcome_coverage.id,
+              assignment: outcome_coverage.assignment) %></p>
+    <p> <%= link_to t(".delete_outcome_coverage"), manage_assessments_outcome_coverage_path(outcome_coverage), method: :delete %> </p>
   </div>
 </div>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -45,6 +45,8 @@ en:
       new:
         add: Add
         headline: Add assignment
+      edit:
+        headline: Edit assignment
     coverages:
       coverage:
         add_another_outcome: Add an outcome
@@ -57,6 +59,8 @@ en:
         add_assignment: Add an Assignment
         assignment_name: In %{name}
         assignment_problem: on %{problem}
+        edit_assignment: Edit Assignment
+        delete_outcome_coverage: Delete
         outcome: Outcome %{label}
     dashboard:
       show:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -3,6 +3,7 @@ en:
     submit:
       assignment:
         create: Add
+        update: Update
       coverage:
         create: Add
         update: Update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     end
 
     resources :outcome_coverages, only: [:destroy] do
-      resources :assignments, only: [:new, :create]
+      resources :assignments, only: [:new, :edit, :create, :update]
     end
   end
 

--- a/spec/features/user_deletes_outcome_coverage_from_a_subject_spec.rb
+++ b/spec/features/user_deletes_outcome_coverage_from_a_subject_spec.rb
@@ -8,7 +8,8 @@ feature "User deletes an outcome coverage for a subject" do
     user = user_with_assessments_access_to(course.department)
 
     visit manage_assessments_course_path(course.id, as: user)
-    first(".class-card-outcomes-wrapper").click_on("Delete")
+    first(".class-card-outcomes-wrapper")
+      .click_on t("manage_assessments.outcome_coverages.outcome_coverage.delete_outcome_coverage")
 
     expect(page).to have_outcome_number_of(1)
   end
@@ -23,7 +24,7 @@ feature "User deletes an outcome coverage for a subject" do
     coverage.outcome_coverages.first.update(assignment: assignment)
 
     visit manage_assessments_course_path(course.id, as: user)
-    click_on "Delete"
+    click_on t("manage_assessments.outcome_coverages.outcome_coverage.delete_outcome_coverage")
 
     expect(page).to have_content(course.number)
     expect(page).to have_content t("manage_assessments.courses.show_without_coverages.no_classes", name: course.name)

--- a/spec/features/user_edits_an_assignment_spec.rb
+++ b/spec/features/user_edits_an_assignment_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+feature "User edits an assignment on an outcome coverage" do
+  scenario "successfully" do
+    assignment = create(:assignment)
+    user = user_with_assessments_access_to(assignment.course.department)
+
+    visit manage_assessments_course_path(assignment.course.id, as: user)
+
+    click_on t("manage_assessments.outcome_coverages.outcome_coverage.edit_assignment")
+    fill_in :assignment_name, with: "Problem Set 2 Edited"
+    fill_in :assignment_problem, with: "Question 4 Edited"
+    click_on t("helpers.submit.coverage.update")
+
+    expect(page).to have_content("Problem Set 2 Edited")
+    expect(page).to have_content("Question 4 Edited")
+  end
+end


### PR DESCRIPTION
A user can now edit an assignment from the `manage_assessments_courses_path`. Here he or she can change the assignment name and/or problem as well as attach student work.

![screen shot 2017-06-19 at 4 40 32 pm](https://user-images.githubusercontent.com/9501674/27305011-10b6d9cc-550e-11e7-8ce8-aecf10d93705.png)
