### PR TITLE
Disallow editing existing coverages

### DIFF
--- a/app/controllers/manage_assessments/coverages_controller.rb
+++ b/app/controllers/manage_assessments/coverages_controller.rb
@@ -8,6 +8,7 @@ module ManageAssessments
 
     def edit
       @coverage = Coverage.find(params[:id])
+      @coverage.outcome_coverages.build
       authorize(@coverage)
     end
 
@@ -26,7 +27,7 @@ module ManageAssessments
       @coverage = Coverage.find(params[:id])
       authorize(@coverage)
 
-      if @coverage.update_attributes(coverage_params)
+      if @coverage.update_attributes(update_coverage_params)
         redirect_to manage_assessments_course_path(@coverage.course)
       else
         render :edit
@@ -45,8 +46,14 @@ module ManageAssessments
         permit(
           :subject_id,
           attachments_attributes: [:id, :file, :_destroy],
-          outcome_coverages_attributes: [:id, :outcome_id, :_destroy]
+          outcome_coverages_attributes: [:outcome_id, :_destroy]
         )
+    end
+
+    def update_coverage_params
+      params.
+        require(:coverage).
+        permit(outcome_coverages_attributes: [:outcome_id, :_destroy])
     end
   end
 end

--- a/app/helpers/coverage_helper.rb
+++ b/app/helpers/coverage_helper.rb
@@ -1,0 +1,5 @@
+module CoverageHelper
+  def available_outcomes(coverage)
+    coverage.course.outcomes.alphabetical - coverage.outcomes
+  end
+end

--- a/app/views/manage_assessments/coverages/_form.html.erb
+++ b/app/views/manage_assessments/coverages/_form.html.erb
@@ -1,20 +1,26 @@
 <%= form.input :subject_id,
   collection: Subject.sorted_by_number,
-  label_method: :to_s %>
+  label_method: :to_s,
+  disabled: form.object.persisted? %>
 
-<%= form.simple_fields_for :outcome_coverages do |outcome_coverage_fields| %>
-  <%= outcome_coverage_fields.input :outcome_id,
-    collection: form.object.course.outcomes,
-    label_method: :to_short_s,
-    required: outcome_coverage_fields.options[:child_index] == 0 %>
+<%= form.simple_fields_for :outcome_coverages,
+  form.object.outcome_coverages.select(&:new_record?) do |fields| %>
+    <%= fields.input :outcome_id,
+      collection: available_outcomes,
+      headline: t("simple_form.headlines.outcome_coverages.outcome_id", count: fields.options[:child_index]),
+      label_method: :to_short_s,
+      required: fields.options[:child_index] == 0 %>
 <% end %>
 
 <div class="nested-form-actions">
   <%= link_to_add_association t(".add_outcome"),
     form,
     :outcome_coverages,
-    render_options: { locals: { outcomes: form.object.course.outcomes } } %>
+    render_options: { locals: { outcomes: available_outcomes } } %>
 </div>
 
-<%= render "attachments/nested_form", form: form %>
+<% if form.object.new_record? %>
+  <%= render "attachments/nested_form", form: form %>
+<% end %>
+
 <%= render "manage_assessments/madlib_controls", form: form %>

--- a/app/views/manage_assessments/coverages/edit.html.erb
+++ b/app/views/manage_assessments/coverages/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :full_bleed do %>
   <div class="madlib-header">
     <h1 class="headline-narrow">
-      Add and Edit Outcomes
+      Add Outcomes
     </h1>
     <h2 class="headline-narrow-subhead">
       <%= @coverage.course.number %>
@@ -11,6 +11,6 @@
   </div>
 <% end %>
 
-<%= madlib_form_for @coverage, url: manage_assessments_course_coverage_path(course_id: @coverage.course.id) do |form| %>
-  <%= render "form", form: form %>
+<%= madlib_form_for @coverage, url: manage_assessments_course_coverage_path(@coverage.course_id) do |form| %>
+  <%= render "form", form: form, available_outcomes: available_outcomes(@coverage) %>
 <% end %>

--- a/app/views/manage_assessments/coverages/new.html.erb
+++ b/app/views/manage_assessments/coverages/new.html.erb
@@ -11,6 +11,6 @@
   </div>
 <% end %>
 
-<%= madlib_form_for @coverage, url: manage_assessments_course_coverages_path(@coverage.course) do |form| %>
-  <%= render "form", form: form %>
+<%= madlib_form_for @coverage, url: manage_assessments_course_coverages_path(@coverage.course_id) do |form| %>
+  <%= render "form", form: form, available_outcomes: available_outcomes(@coverage) %>
 <% end %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -22,7 +22,10 @@ en:
       coverage:
         subject_id: In
       outcome_coverages:
-        outcome_id: students learn
+        outcome_id:
+          zero: students learn
+          one: and
+          other: and
     hints:
       direct_assessment:
         assignment_description: Brief description of the topic of this


### PR DESCRIPTION
Consider the scenario where a user:

1. Adds outcomes to subject 1.00
2. Adds assignments to those outcomes
3. Clicks "Add an outcome" to add another outcome to this subject

Previous to this change, while adding additional outcomes the user could
also change the subject or edit the previous coverage to point at
different coverages. This could potentially cause assignments, results,
and attachment to become disconnected from the actual outcome they were
intended for.

Now, when a user elects to "Add an outcome" they can only add new
outcomes. They cannot change the subject or any previously existing
outcomes.

If the user wants to remove an outcome from a subject, they should use
the `Delete` link on the listing page.