### PR TITLE
Add confirmation when archiving outcome coverage

### DIFF
--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -37,7 +37,8 @@
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),
             manage_assessments_outcome_coverage_path(outcome_coverage),
-            method: :delete %>
+            method: :delete,
+            data: { confirm: t(".delete_outcome_coverage_confirmation") } %>
     </div>
   </div>
 </div>

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -23,6 +23,9 @@ en:
         assignment_problem: on %{problem}
         edit_assignment: Edit Assignment
         delete_outcome_coverage: Delete
+        delete_outcome_coverage_confirmation: You are about to remove this
+          outcome from this class archiving the associated assignment and
+          results. Are you sure you want to continue?
         outcome: Outcome %{label}
     dashboard:
       show:


### PR DESCRIPTION
This is recoverable, but (currently) only with help from Jon or a
developer. Let's give them a quick "are you sure?" message...


![abet_outcomes_assessment](https://user-images.githubusercontent.com/152152/27341524-85e47180-55ab-11e7-8116-beb3c21b623b.png)