### PR TITLE
Sort outcomes alphabetically within each class

### DIFF
--- a/app/views/manage_assessments/coverages/_coverage.html.erb
+++ b/app/views/manage_assessments/coverages/_coverage.html.erb
@@ -12,7 +12,7 @@
     </span>
   </h2>
 
-  <%= render coverage.outcome_coverages %>
+  <%= render coverage.outcome_coverages.sort_by(&:outcome_label) %>
 
   <%= link_to(edit_manage_assessments_course_coverage_path(coverage, course_id: coverage.course_id), html_options = {class: "add-item add-item-short"}) do %>
     <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>


### PR DESCRIPTION
I tried and failed to do this within our `includes` statements in the
controller. It requires adding explicit associations that have ordering
provided, but getting those to work with our `has_many: :through`
relationships was proving difficult. We're not dealing with a ton of
records here, so an in memory sort shouldn't be bad.