### PR TITLE
User can add a result to an assignment

### DIFF
--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -34,6 +34,7 @@
               edit_manage_assessments_outcome_coverage_assignment_path(
                 outcome_coverage_id: outcome_coverage.id,
                 assignment: outcome_coverage.assignment) %>
+        <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),
             manage_assessments_outcome_coverage_path(outcome_coverage),

--- a/config/locales/manage_assessments.en.yml
+++ b/config/locales/manage_assessments.en.yml
@@ -19,6 +19,7 @@ en:
     outcome_coverages:
       outcome_coverage:
         add_assignment: Add an Assignment
+        add_result: Add Result
         assignment_name: In %{name}
         assignment_problem: on %{problem}
         edit_assignment: Edit Assignment


### PR DESCRIPTION
A user can now add a result to an assignment from the `manage_assessments_courses_path` using the Add Result link. This link can be used to add multiple results across semesters and years.