### PR TITLE
Archived outcomes shown in unmatched outcomes list

### DIFF
--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -4,7 +4,7 @@ class Outcome < ActiveRecord::Base
   belongs_to :course, counter_cache: true
 
   has_one :department, through: :course
-  has_many :outcome_coverages
+  has_many :outcome_coverages, -> { where archived: false }
   has_many :alignments
   has_many :standard_outcomes, through: :alignments
 


### PR DESCRIPTION
On the `manage_assessments_courses_path`, archived outcomes now appear in the list of unmatched outcomes as clickable. Previously, archived outcomes were displayed as crossed-out meaning that the user could not re-add an archived outcome by selecting that outcome under the Unmatched Outcomes tab. 