### PR TITLE
Disable HTML5 required validation on MadLib forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,10 @@ module ApplicationHelper
   end
 
   def madlib_form_for(path, options = {}, &block)
-    options = options.deep_merge(html: { class: :madlib }, wrapper: :madlib)
+    options = options.deep_merge(
+      html: { class: :madlib, novalidate: true },
+      wrapper: :madlib,
+    )
     simple_form_for(path, options, &block)
   end
 end

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -14,13 +14,17 @@ class Coverage < ActiveRecord::Base
     allow_destroy: true,
     reject_if: :all_blank
 
-  validates :subject_id, presence: true, uniqueness: { scope: [:course_id, :archived] }, unless: :archived
+  validates :subject_id,
+    presence: true,
+    uniqueness: { scope: [:course_id, :archived], unless: :archived }
   validate :must_have_outcomes
 
   private
 
   def must_have_outcomes
     if outcome_coverages.empty? || all_outcome_coverages_marked_for_destruction?
+      outcome_coverage = outcome_coverages.build
+      outcome_coverage.errors.add(:outcome_id, :blank)
       errors.add(:base, :outcomes_required)
     end
   end

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -6,7 +6,8 @@ class OutcomeCoverage < ActiveRecord::Base
 
   delegate :label, :nickname, to: :outcome, prefix: true
 
-  validates :outcome_id, uniqueness: { scope: [:coverage_id, :archived] }, unless: :archived
+  validates :outcome_id,
+    uniqueness: { scope: [:coverage_id, :archived], unless: :archived }
 
   has_paper_trail
 

--- a/app/views/manage_assignments/coverages/_form.html.erb
+++ b/app/views/manage_assignments/coverages/_form.html.erb
@@ -8,8 +8,7 @@
     <%= fields.input :outcome_id,
       collection: available_outcomes,
       headline: t("simple_form.headlines.outcome_coverages.outcome_id", count: fields.options[:child_index]),
-      label_method: :to_short_s,
-      required: fields.options[:child_index] == 0 %>
+      label_method: :to_short_s %>
 <% end %>
 
 <div class="nested-form-actions">

--- a/app/views/manage_assignments/coverages/_outcome_coverage_fields.html.erb
+++ b/app/views/manage_assignments/coverages/_outcome_coverage_fields.html.erb
@@ -2,8 +2,7 @@
   <%= f.input :outcome_id,
     headline: "and",
     collection: outcomes,
-    label_method: :to_short_s,
-    required: false %>
+    label_method: :to_short_s %>
 
   <% if f.object.new_record? %>
     <%= link_to_remove_association t(".remove"), f, class: "remove-outcome" %>

--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -35,7 +35,23 @@ feature "user adds coverage to a course" do
     expect(page).to have_prepopulated_select_box(unmatched_outcome.nickname)
   end
 
+  scenario "sees errors for missing required fields", js: true do
+    course = create(:course)
+    create(:outcome, course: course)
+    user = user_with_assignments_access_to(course.department)
+
+    visit new_manage_assignments_course_coverage_path(course, as: user)
+    click_button t('helpers.submit.coverage.create')
+
+    expect(find(".coverage_subject_id")).to have_content(blank_error)
+    expect(find(".coverage_outcome_coverages_outcome_id")).to have_content(blank_error)
+  end
+
   def have_prepopulated_select_box(text)
     have_css("select", text: text)
+  end
+
+  def blank_error
+    t("activerecord.errors.messages.blank")
   end
 end

--- a/spec/support/selectize.rb
+++ b/spec/support/selectize.rb
@@ -1,6 +1,6 @@
 module SelectizeHelper
   def selectize(item, from:)
-    container = find_field(from, visible: false).first(:xpath, ".//..")
+    container = all(:field, from, visible: false).last.first(:xpath, ".//..")
     container.find(".selectize-control").click
     container.find("div.option", text: item).click
   end


### PR DESCRIPTION
We now have nice custom styling on errors for madlib forms. HTML5
validations (of which we were only using the `required` validations) are
nice when they work, but they don't notify the user of any problems on
our `selectize` select boxes because the underlying input is actually
hidden.

We can let these hit the server validation instead so the user gets
better error messages. To facilitate this, I added the `novalidate`
attribute to the form tag for our madlib forms.

This change also includes some validation fixes so errors that the
server encounter are rendered properly.

* Scope the exception to uniqueness validations appropriately. We were
previously excepting all validations on those fields when we only wanted
to except the uniqueness validation.
* Add a user visible validation to the first blank outcome_coverage when
a coverage has no outcomes.