### PR TITLE
Remove content type validation on attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -8,7 +8,7 @@ class Attachment < ActiveRecord::Base
     path: ":attachments_root/:attachable_type/:attachable_id/:id/:filename",
     s3_permissions: :private
 
-  validates_attachment_content_type :file, content_type: /\Aapplication\/pdf\z/
+  do_not_validate_attachment_file_type :file
 
   def name
     file_file_name


### PR DESCRIPTION
We discussed this with Jon a couple of weeks ago who said it was
difficult to predict what types of files people might upload. Images,
MS Word docs, Excel files, Open Office, Text, PDF, PostScript... its all
a possibility.

We discussed the risks and Jon decided to opt not to restrict the
content type given that the set of users is restricted.