### PR TITLE
Activity feed links auto scroll

### DIFF
--- a/app/views/activities/_assignment_activity.html.erb
+++ b/app/views/activities/_assignment_activity.html.erb
@@ -1,6 +1,6 @@
 <%= t(".event.#{activity.event}_#{activity.item_type.downcase}_html",
     name: link_to(
       activity.item.name,
-      manage_assessments_course_path(activity.item.course)
+      manage_assessments_course_path(id: activity.item.course, anchor: dom_id(activity.item))
     ),
     subject: activity.item.subject_name) %>

--- a/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assessments/outcome_coverages/_outcome_coverage.html.erb
@@ -10,7 +10,7 @@
 
   <div class="class-card-assignments">
     <% if outcome_coverage.assignment.present? %>
-    <p class="class-card-assignment">
+    <p class="class-card-assignment" id="<%= dom_id(outcome_coverage.assignment) %>">
       <%= t(".assignment_name", name: outcome_coverage.assignment.name) %>
       <%= t(".assignment_problem",
       problem: outcome_coverage.assignment.problem) if outcome_coverage.assignment.problem.present? %>


### PR DESCRIPTION
The activity feed reports when an assignment has been created or updated, and includes a link to the specific assignment. Now when a user clicks on an assignment link, she will be directed to the point on the courses page that lists the assignment. To accomplish this feature, an anchor is passed to the `manage_assessments_course_path` when the activity type is assignment. The `id` of that assignment is added to the html on the courses page.