### PR TITLE
Add tab bar to coverage view

### DIFF
--- a/app/views/manage_assessments/courses/show.html.erb
+++ b/app/views/manage_assessments/courses/show.html.erb
@@ -1,3 +1,5 @@
+<% tab(TabHelper::ASSIGNMENTS) %>
+
 <%= content_for :full_bleed do %>
   <h1 class="headline-narrow headline-narrow-pad">
     <%= @course.name %>


### PR DESCRIPTION
The forms for adding a class, outcome, or assignment don't have the tab
bar because it distracts from the task at hand, but this listing view
should provide connection to the other areas of the site.