### PR TITLE
Order coverages by their subject number

### DIFF
--- a/app/models/course_coverage.rb
+++ b/app/models/course_coverage.rb
@@ -1,4 +1,10 @@
 class CourseCoverage < SimpleDelegator
+  def ordered_coverages
+    @ordered_coverages ||= coverages.sort_by do |coverage|
+      coverage.subject.number
+    end
+  end
+
   def has_coverages?
     coverages.where(archived: false).present?
   end

--- a/app/views/manage_assignments/courses/show.html.erb
+++ b/app/views/manage_assignments/courses/show.html.erb
@@ -21,7 +21,7 @@
 
   <section id="matched_outcomes" class="split-tab-panel" data-content="matched">
     <div class="container">
-      <%= render @course.coverages %>
+      <%= render @course.ordered_coverages %>
       <%= link_to new_manage_assignments_course_coverage_path(@course),
         class: "add-item add-item-subtle add-item-short" do %>
         <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>

--- a/spec/models/course_coverage_spec.rb
+++ b/spec/models/course_coverage_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe CourseCoverage do
+  describe "#ordered_coverages" do
+    it "sorts by the associated subject number" do
+      course = create(:course)
+      subject_a = create(:subject, number: 2)
+      subject_b = create(:subject, number: 1)
+      coverage_a = create(:coverage, course: course, subject: subject_a)
+      coverage_b = create(:coverage, course: course, subject: subject_b)
+      course_coverage = CourseCoverage.new(course)
+
+      expect(course_coverage.ordered_coverages).to eq [coverage_b, coverage_a]
+    end
+  end
+end


### PR DESCRIPTION
When we display coverage by course, we want to order the coverages by
their subject. Currently, the order is non-deterministic.

This performs the sort in memory to avoid having to add an explicit
"ordered_coverages" association to Course to do it in SQL with eager
loading. I considered that option, but it would have also required
rewriting some other methods on `CourseCoverage` to assume use of the
ordered collection as well, and that didn't seem desirable.