### PR TITLE
Remove choose file button from edit assignment

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -3,7 +3,7 @@ $(function() {
   var fileName = ".file-name";
 
   $(document).on("cocoon:before-insert", ".attachments", function(e, insertedItem) {
-    $(insertedItem).find(fileInput).hide().click();
+    $(insertedItem).find(fileInput).click();
 
     $(insertedItem).on("change", function(ev) {
       var selectedFileName = ev.target.files[0].name;

--- a/app/assets/stylesheets/components/_add-item.scss
+++ b/app/assets/stylesheets/components/_add-item.scss
@@ -68,3 +68,7 @@
     text-align: right;
   }
 }
+
+.is-hidden {
+  display: none;
+}

--- a/app/views/attachments/_fields.html.erb
+++ b/app/views/attachments/_fields.html.erb
@@ -1,6 +1,6 @@
 <li class="attachment">
   <%= f.hidden_field :id %>
-  <%= f.file_field :file, as: :file %>
+  <%= f.file_field :file, as: :file, class: "is-hidden" %>
 
   <% if f.object.persisted? %>
     <span class="file-name"><%= f.object.name %></span>


### PR DESCRIPTION
[Trello card](https://trello.com/c/P0dYb3tH)
This branch removes the choose file button present on the edit
assignment page.