### PR TITLE
Always show remove attachment link

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -1,16 +1,13 @@
 $(function() {
   var fileInput = "input[type='file']";
   var fileName = ".file-name";
-  var removeLink = "a.remove_fields";
 
   $(document).on("cocoon:before-insert", ".attachments", function(e, insertedItem) {
     $(insertedItem).find(fileInput).hide().click();
-    $(insertedItem).find(removeLink).hide();
 
     $(insertedItem).on("change", function(ev) {
       var selectedFileName = ev.target.files[0].name;
       $(this).find(fileName).text(selectedFileName);
-      $(this).find(removeLink).show();
     });
   });
 });


### PR DESCRIPTION
If the user cancels a file attachment dialog, they previously had no way
to remove the empty file input. It wasn't necessary to do so, but I can
definitely see confusion resulting from that.

Ideally there would be an event we could handle when the user cancels
that dialog, but there is not. No good workarounds exist for this
either. As a stopgap solution, this change removes the code that was
keeping the "delete" link hidden until there was a file added.

Now the user can at least manually clean up after themselves.