### PR TITLE
Render all attachments above the "add" button

### DIFF
--- a/app/views/attachments/_fields.html.erb
+++ b/app/views/attachments/_fields.html.erb
@@ -1,4 +1,5 @@
 <li class="attachment">
+  <%= f.hidden_field :id %>
   <%= f.file_field :file, as: :file %>
 
   <% if f.object.persisted? %>

--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -1,6 +1,6 @@
 <div class="nested-form-actions">
   <ul class="attachments">
-    <%= form.fields_for :attachments, wrapper: false do |attachment_fields| %>
+    <%= form.fields_for :attachments, wrapper: false, include_id: false do |attachment_fields| %>
       <%= render "attachments/fields", f: attachment_fields %>
     <% end %>
 
@@ -9,10 +9,6 @@
         form,
         :attachments,
         partial: "attachments/fields",
-        data: {
-          association_insertion_method: "append",
-          association_insertion_node: ".attachments"
-        },
         class: "add-item add-item-short add-item-subtle add-item-attachment"
       ) do %>
         <%= inline_svg "paper_clip.svg", class: "add-item-icon" %>


### PR DESCRIPTION
Previous to this change, pre-existing attachments would render above the
"Add and Attachment" button while new attachments would render below.
They now all render above the button, which is a sibling list element to
the attachments themselves.

I also updated the `fields_for` call so it doesn't render a hidden
`input` between the `li` tags for the attachment id, which is not valid
HTML. Instead, we manually render the `id` inside the `li`.