### PR TITLE
Add outcome information to assignment form

### DIFF
--- a/app/views/manage_assignments/assignments/_form.html.erb
+++ b/app/views/manage_assignments/assignments/_form.html.erb
@@ -1,3 +1,14 @@
+<div class="madlib-statement">
+  <p class="headline-poster">
+    <%= t(
+      ".intro",
+      subject_number:  form.object.subject.number,
+      outcome_label: form.object.outcome.label,
+      outcome_nickname: form.object.outcome.nickname,
+    ) %>
+  </p>
+</div>
+
 <%= form.input :name %>
 <%= form.input :problem %>
 

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -13,6 +13,9 @@ en:
         headline: Add assignment
       edit:
         headline: Edit assignment
+      form:
+        intro: "In %{subject_number}, mastery of Outcome %{outcome_label}:
+          %{outcome_nickname}"
     coverages:
       coverage:
         add_another_outcome: Add an outcome


### PR DESCRIPTION
The assignment form didn't tell the user what subject or outcome the
assignment was for.