### PR TITLE
Display username on activity feed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   protect_from_forgery with: :exception
+  before_action :set_paper_trail_whodunnit
   after_action :verify_authorized, except: [:index]
   after_action :verify_policy_scoped, only: [:index]
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -34,4 +34,24 @@ feature "User views activity feed" do
                                     assignment: other_department_result.assignment.name,
                                     subject: other_department_result.assignment.subject)
   end
+
+  scenario "sees her username is associated with each activity" do
+    outcome = create(:outcome)
+    course = outcome.course
+    coverage = create(:coverage, course: course, outcomes: [outcome])
+    outcome_coverage = OutcomeCoverage.first
+    user = user_with_assignments_access_to(course.department)
+    user_creates_an_assignment(outcome_coverage, user)
+
+    visit activities_path(as: user)
+
+    expect(page).to have_content user.username
+  end
+
+  def user_creates_an_assignment(outcome_coverage, user)
+    visit new_manage_assignments_outcome_coverage_assignment_path(outcome_coverage, as: user)
+    fill_in :assignment_name, with: "Problem Set 2"
+    fill_in :assignment_problem, with: "Question 4"
+    click_on t("helpers.submit.coverage.create")
+  end
 end


### PR DESCRIPTION
This branch displays the user responsible for the activity listed on the Activity Feed. To accomplish this feature, `before_action :set_paper_trail_whodunnit` has been added to the `Applications Controller`. As of PaperTrail 5.0, this line is no longer a default of PaperTrail ([see change logs](https://github.com/airblade/paper_trail/blob/master/CHANGELOG.md)).

![screen shot 2017-06-26 at 2 08 33 pm](https://user-images.githubusercontent.com/9501674/27554044-29d8dfc8-5a7b-11e7-864f-91ece5355ecb.png)
