### PR TITLE
Typography tweaks for adding and editing an assignment intro

### DIFF
--- a/app/assets/stylesheets/components/_headline-narrow.scss
+++ b/app/assets/stylesheets/components/_headline-narrow.scss
@@ -9,7 +9,7 @@
   margin-bottom: 0.2em;
 
   @include media($medium-screen-up) {
-    font-size: 2.75em;
+    font-size: 2.35em;
   }
 
   .madlib-header & {

--- a/app/assets/stylesheets/components/_madlib-leadin.scss
+++ b/app/assets/stylesheets/components/_madlib-leadin.scss
@@ -1,0 +1,8 @@
+.madlib-leadin {
+  margin-bottom: $base-spacing;
+  padding-left: $smallest-spacing;
+
+  @include media($medium-screen-up) {
+    @include margin($large-spacing null);
+  }
+}

--- a/app/views/manage_assignments/assignments/_form.html.erb
+++ b/app/views/manage_assignments/assignments/_form.html.erb
@@ -1,10 +1,15 @@
-<div class="madlib-statement">
-  <p class="headline-poster">
+<div class="madlib-leadin">
+  <p class="headline-poster headline-poster-copy">
     <%= t(
-      ".intro",
-      subject_number:  form.object.subject.number,
-      outcome_label: form.object.outcome.label,
-      outcome_nickname: form.object.outcome.nickname,
+    ".intro_subject",
+    subject_number: form.object.subject.number,
+    ) %>
+  </p>
+  <p class="headline-poster headline-poster-copy">
+    <%= t(
+    ".intro_outcome",
+    outcome_label: form.object.outcome.label,
+    outcome_nickname: form.object.outcome.nickname,
     ) %>
   </p>
 </div>

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -14,7 +14,8 @@ en:
       edit:
         headline: Edit assignment
       form:
-        intro: "In %{subject_number}, mastery of Outcome %{outcome_label}:
+        intro_subject: "In %{subject_number} —"
+        intro_outcome: "Mastery of Outcome %{outcome_label}:
           %{outcome_nickname}"
     coverages:
       coverage:


### PR DESCRIPTION
This design is more holistic. The type styles now echo those of the blank
state for a course.

![screen shot 2017-06-26 at 3 15 03 pm](https://user-images.githubusercontent.com/5566826/27556110-50b6955c-5a82-11e7-8db7-56419cbb6b6a.png)
![screen shot 2017-06-26 at 3 14 57 pm](https://user-images.githubusercontent.com/5566826/27556111-50bd2fca-5a82-11e7-9b94-7eeb1bc310de.png)


https://trello.com/c/KR5D5uBL