### PR TITLE
Edit assignment by clicking text

### DIFF
--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -11,9 +11,13 @@
   <div class="class-card-assignments">
     <% if outcome_coverage.assignment.present? %>
     <p class="class-card-assignment" id="<%= dom_id(outcome_coverage.assignment) %>">
-      <%= t(".assignment_name", name: outcome_coverage.assignment.name) %>
-      <%= t(".assignment_problem",
-      problem: outcome_coverage.assignment.problem) if outcome_coverage.assignment.problem.present? %>
+      <%= link_to edit_manage_assignments_outcome_coverage_assignment_path(
+            outcome_coverage_id: outcome_coverage.id,
+            assignment: outcome_coverage.assignment) do %>
+              <%= t(".assignment_name", name: outcome_coverage.assignment.name) %>
+              <%= t(".assignment_problem",
+                  problem: outcome_coverage.assignment.problem) if outcome_coverage.assignment.problem.present? %>
+      <% end %>
     </p>
     <p class="outcome-card-description">
       <%= outcome_coverage.outcome.description %>
@@ -30,10 +34,6 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
-        <%= link_to t(".edit_assignment"),
-              edit_manage_assignments_outcome_coverage_assignment_path(
-                outcome_coverage_id: outcome_coverage.id,
-                assignment: outcome_coverage.assignment) %>
         <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),

--- a/spec/features/user_edits_an_assignment_spec.rb
+++ b/spec/features/user_edits_an_assignment_spec.rb
@@ -6,8 +6,8 @@ feature "User edits an assignment on an outcome coverage" do
     user = user_with_assignments_access_to(assignment.course.department)
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
-
-    click_on t("manage_assignments.outcome_coverages.outcome_coverage.edit_assignment")
+    
+    click_on assignment.name
     fill_in :assignment_name, with: "Problem Set 2 Edited"
     fill_in :assignment_problem, with: "Question 4 Edited"
     click_on t("helpers.submit.coverage.update")


### PR DESCRIPTION
This branch removes the Edit Assignment link. Now a user, edits an
assignment by clicking directly on the assignment text (the name of the
assignment and, if present, the problem name).

![screen shot 2017-06-26 at 3 34 41 pm](https://user-images.githubusercontent.com/9501674/27558980-e532c016-5a8c-11e7-8f89-1688853704a0.png)
