### PR TITLE
Handle user selecting same outcome twice

### DIFF
--- a/spec/features/user_adds_coverage_to_a_course_spec.rb
+++ b/spec/features/user_adds_coverage_to_a_course_spec.rb
@@ -13,6 +13,8 @@ feature "user adds coverage to a course" do
     selectize first_outcome.nickname, from: "Outcome"
     click_on t('manage_assignments.coverages.form.add_outcome')
     selectize second_outcome.nickname, from: "Outcome"
+    click_on t('manage_assignments.coverages.form.add_outcome')
+    selectize first_outcome.nickname, from: "Outcome"
     click_button t('helpers.submit.coverage.create')
 
     within("#matched_outcomes") do


### PR DESCRIPTION
The outcome dropdowns on the coverage forms are populated with outcomes
that have not yet been used for the given subject (if known). The user
could still select the same available outcome twice on the same form.
Prior to this change, that would result in an application error because
the uniqueness validation that is designed to prevent this does not work
on objects that have not yet been persisted. As a result, Rails thinks
the outcome coverages are valid, but the database rejects them as
violating a unique constraint.

We now remove the duplicated outcome from the params before saving. If
the user specifies "Outcome A" twice, we will persist one of them.