### PR TITLE
Limit attachment collisions between environments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -5,7 +5,7 @@ class Attachment < ActiveRecord::Base
 
   has_attached_file :file,
     url: "/attachments/:id",
-    path: ":attachments_root/:attachable_type/:attachable_id/:id/:filename",
+    path: ":attachments_root/:attachable_type/:attachable_id/:updated_at/:filename",
     s3_permissions: :private
 
   do_not_validate_attachment_file_type :file


### PR DESCRIPTION
It was possible (though unlikely) that a user could upload an attachment
named, for exmaple, `syllabus.pdf` in staging that could potentially
clobber a production attachment with the same name. For this to happen
it would have to:

* Be attached to a coverage or assignment that has the same type and ID
  as the production attachment.
* Have the same attachment id.

This is pretty unlikely, but we can make it even more unlikely by
replacing the attachment id in the path with the attachment updated_at
timestamp.