### PR TITLE
Use ApplicationRecord over ActiveRecord::Base

### DIFF
--- a/app/controllers/manage_outcomes/outcomes_controller.rb
+++ b/app/controllers/manage_outcomes/outcomes_controller.rb
@@ -63,7 +63,7 @@ class ManageOutcomes::OutcomesController < ApplicationController
 
   def persist_outcome(outcome)
     if outcome.valid?
-      ActiveRecord::Base.transaction do
+      ApplicationRecord.transaction do
         authorize(outcome)
         outcome.course.adopt_custom_outcomes!
         outcome.save!

--- a/app/models/alignment.rb
+++ b/app/models/alignment.rb
@@ -1,4 +1,4 @@
-class Alignment < ActiveRecord::Base
+class Alignment < ApplicationRecord
   LOW = "Low alignment".freeze
   MODERATE = "Moderate alignment".freeze
   HIGH = "High alignment".freeze

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,4 +1,4 @@
-class Assignment < ActiveRecord::Base
+class Assignment < ApplicationRecord
   belongs_to :outcome_coverage
 
   has_one :outcome, through: :outcome_coverage

--- a/app/models/assignment_report.rb
+++ b/app/models/assignment_report.rb
@@ -1,4 +1,4 @@
-class AssignmentReport < ActiveRecord::Base
+class AssignmentReport < ApplicationRecord
   def self.for(course)
     where(course_id: course)
   end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,4 +1,4 @@
-class Attachment < ActiveRecord::Base
+class Attachment < ApplicationRecord
   EXPIRE_TIMEFRAME = 60.seconds
 
   belongs_to :attachable, polymorphic: true

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,4 @@
-class Course < ActiveRecord::Base
+class Course < ApplicationRecord
   belongs_to :department
 
   has_many :coverages, -> { where archived: false }

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -1,4 +1,4 @@
-class Coverage < ActiveRecord::Base
+class Coverage < ApplicationRecord
   belongs_to :course
   belongs_to :subject, required: true
 

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,3 +1,3 @@
-class Department < ActiveRecord::Base
+class Department < ApplicationRecord
   has_many :courses
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,4 +1,4 @@
-class Outcome < ActiveRecord::Base
+class Outcome < ApplicationRecord
   attribute :label, Label.new
 
   belongs_to :course, counter_cache: true

--- a/app/models/outcome_coverage.rb
+++ b/app/models/outcome_coverage.rb
@@ -1,4 +1,4 @@
-class OutcomeCoverage < ActiveRecord::Base
+class OutcomeCoverage < ApplicationRecord
   belongs_to :coverage
   belongs_to :outcome, required: true
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,4 +1,4 @@
-class Result < ActiveRecord::Base
+class Result < ApplicationRecord
   SEMESTERS = ["FA", "JA", "SP"]
   YEARS = (2012..2019).to_a
 

--- a/app/models/standard_outcome.rb
+++ b/app/models/standard_outcome.rb
@@ -1,4 +1,4 @@
-class StandardOutcome < ActiveRecord::Base
+class StandardOutcome < ApplicationRecord
   attribute :label, Label.new
 
   has_many :alignments

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,4 @@
-class Subject < ActiveRecord::Base
+class Subject < ApplicationRecord
   belongs_to :department, foreign_key: :department_number, primary_key: :number
 
   has_many :coverages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   validates :email, presence: true, email: true
 
   delegate :admin?, :read?, :manage_results?, :manage_assignments?,

--- a/app/services/adoption.rb
+++ b/app/services/adoption.rb
@@ -9,7 +9,7 @@ class Adoption
   end
 
   def process
-    ActiveRecord::Base.transaction do
+    ApplicationRecord.transaction do
       adoptable_outcomes.each do |adoptable_outcome|
         outcome = course.outcomes.build(
           nickname: adoptable_outcome.nickname,

--- a/app/services/archive.rb
+++ b/app/services/archive.rb
@@ -24,7 +24,7 @@ class Archive
   end
 
   def archive_coverage_and(outcome_coverage)
-    ActiveRecord::Base.transaction do
+    ApplicationRecord.transaction do
       outcome_coverage.coverage.update!(archived: true)
       outcome_coverage.update!(archived: true)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-ActiveRecord::Base.transaction do
+ApplicationRecord.transaction do
   Department.find_or_create_by(name: "Civil and Environmental Engineering", slug: "D_CEE", number: 1)
   Department.find_or_create_by(name: "Mechanical Engineering", slug: "D_MECHE", number: 2)
   Department.find_or_create_by(name: "DMSE", slug: "D_DMSE", number: 3)


### PR DESCRIPTION
Rails 5 introduced `ApplicationRecord` which is meant to be the base
class for your active record objects. This gives you a safe place to
extend all of them, if desired. While we don't make use this, it's best
to maintain parity with the latest versions of Rails when you can.