### PR TITLE
Require results to have an assignment id

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -4,8 +4,7 @@ class Result < ApplicationRecord
 
   before_save :denormalize_department
 
-  belongs_to :assessment, counter_cache: true
-  belongs_to :assignment, required: true
+  belongs_to :assignment
   belongs_to :department
 
   validates :percentage, presence: true, inclusion: { in: 0..100 }

--- a/db/migrate/20170628173632_add_assignment_id_constraint_to_results.rb
+++ b/db/migrate/20170628173632_add_assignment_id_constraint_to_results.rb
@@ -1,0 +1,5 @@
+class AddAssignmentIdConstraintToResults < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :results, :assignment_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620185115) do
+ActiveRecord::Schema.define(version: 20170628173632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20170620185115) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "department_id"
-    t.bigint "assignment_id"
+    t.bigint "assignment_id", null: false
     t.index ["assessment_id", "year", "semester"], name: "index_results_on_assessment_id_and_year_and_semester", unique: true
     t.index ["assignment_id", "year", "semester"], name: "index_results_on_assignment_id_and_year_and_semester", unique: true
     t.index ["assignment_id"], name: "index_results_on_assignment_id"


### PR DESCRIPTION
Now that the historical data has been imported, all existing results
have an assignment id. We can now mark this as required.