### PR TITLE
Moving the delete control for an outcome

### DIFF
--- a/app/assets/stylesheets/components/_class-card.scss
+++ b/app/assets/stylesheets/components/_class-card.scss
@@ -42,9 +42,26 @@
 }
 
 .class-card-outcomes-wrapper {
-  @include padding($small-spacing null);
+  @include padding($base-spacing null);
   display: flex;
   flex-wrap: wrap;
+  position: relative;
+
+  @at-root {
+    .delete-outcome-coverage {
+      font-size: $small-font-size;
+      opacity: 0.50;
+      position: absolute;
+      right: 0;
+      top: calc(#{$base-spacing} + 0.75em);
+
+      &:active,
+      &:focus,
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
 
   a {
     @include anchor-color($base-font-color);
@@ -79,8 +96,6 @@
   margin-bottom: 0.5em;
 
   &.add-assignment {
-    margin-left: -$small-spacing;
-
     a {
       @include anchor-color($mit-red);
       border-bottom: $thick-border-width solid $mit-red;
@@ -92,6 +107,5 @@
   @include margin($base-spacing null);
   display: flex;
   font-family: $sans-serif-narrow;
-  font-size: $small-font-size;
   justify-content: space-between;
 }

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -24,8 +24,10 @@
     </p>
     <% else %>
     <p class="class-card-outcome class-card-assignment add-assignment">
-      <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
-      <%= link_to t(".add_assignment"), new_manage_assignments_outcome_coverage_assignment_path(outcome_coverage) %>
+      <%= link_to new_manage_assignments_outcome_coverage_assignment_path(outcome_coverage) do %>
+        <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
+        <%= t(".add_assignment") %>
+      <% end %>
     </p>
     <p class="outcome-card-description">
       <%= outcome_coverage.outcome.description %>
@@ -34,10 +36,14 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
-        <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
+        <%= link_to new_manage_results_assignment_result_path(outcome_coverage.assignment) do %>
+          <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
+          <%= t(".add_result") %>
+        <% end %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),
             manage_assignments_outcome_coverage_path(outcome_coverage),
+            class: "delete-outcome-coverage",
             method: :delete,
             data: { confirm: t(".delete_outcome_coverage_confirmation") } %>
     </div>


### PR DESCRIPTION
This creates a stronger association with what is being deleted (the
outcome) and the control.

![delete](https://user-images.githubusercontent.com/5566826/27657957-5fa975d4-5c1c-11e7-8871-9762b9589a68.gif)
