### PR TITLE
View and delete attachments from courses page

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -12,7 +12,7 @@ $(function() {
   });
 });
 
-$(document).on("click", function(e) {
-    e.preventDefault();
-   $("#attachments-list").toggleClass("is-hidden");
+$(".assignment-attachments").on("click", function(e) {
+  e.preventDefault();
+  $(this).toggleClass("is-hidden");
 });

--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -11,8 +11,3 @@ $(function() {
     });
   });
 });
-
-$(".assignment-attachments").on("click", function(e) {
-  e.preventDefault();
-  $(this).toggleClass("is-hidden");
-});

--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -11,3 +11,8 @@ $(function() {
     });
   });
 });
+
+$(document).on("click", function(e) {
+    e.preventDefault();
+   $("#attachments-list").toggleClass("is-hidden");
+});

--- a/app/assets/javascripts/expandable.js
+++ b/app/assets/javascripts/expandable.js
@@ -1,0 +1,9 @@
+$(function() {
+  $("[data-expands]").on("click", function(e) {
+    var expander = $(this);
+    var expansionTarget = expander.data("expands");
+
+    expander.siblings(expansionTarget).toggleClass("is-hidden");
+  });
+});
+

--- a/app/controllers/manage_assignments/attachments_controller.rb
+++ b/app/controllers/manage_assignments/attachments_controller.rb
@@ -6,5 +6,14 @@ module ManageAssignments
 
       redirect_to @attachment.expiring_url
     end
+
+    def destroy
+      attachment = Attachment.find(params[:id])
+      authorize(attachment)
+
+      attachment.destroy!
+
+      redirect_to manage_assignments_course_path(attachment.attachable.course)
+    end
   end
 end

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -2,4 +2,8 @@ class AttachmentPolicy < ApplicationPolicy
   def show?
     user.manage_assignments?(record.course_department)
   end
+
+  def destroy?
+    show?
+  end 
 end

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,4 +1,7 @@
-<table class="assignment-attachments">
+<%= link_to t(".attachments-expandable-link"), "javascript:void(0)",
+  data: { expands: ".assignment-attachments" } %>
+
+<table class="assignment-attachments is-hidden">
   <tbody>
     <% attachments.each do |attachment| %>
       <tr>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,4 +1,4 @@
-<table class="assignment-attachments" id="attachments-list">
+<table class="assignment-attachments">
   <tbody>
     <% attachments.each do |attachment| %>
       <tr>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,4 +1,4 @@
-<table class="assignment-attachments">
+<table class="assignment-attachments" id="attachments-list">
   <tbody>
     <% attachments.each do |attachment| %>
       <tr>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,9 +1,11 @@
-<table>
+<table class="assignment-attachments">
   <tbody>
     <% attachments.each do |attachment| %>
       <tr>
         <td><%= attachment.file_file_name %></td>
-        <td><%= link_to "Delete" %></td>
+        <td><%= link_to "Delete",
+              manage_assignments_attachment_path(attachment),
+              method: :delete %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -3,7 +3,7 @@
     <% attachments.each do |attachment| %>
       <tr>
         <td><%= attachment.file_file_name %></td>
-        <td><%= link_to "Delete",
+        <td><%= link_to t(".delete-link"),
               manage_assignments_attachment_path(attachment),
               method: :delete %></td>
       </tr>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,0 +1,10 @@
+<table>
+  <tbody>
+    <% attachments.each do |attachment| %>
+      <tr>
+        <td><%= attachment.file_file_name %></td>
+        <td><%= link_to "Delete" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -34,12 +34,20 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
+
+
         <% if outcome_coverage.assignment.attachments.present? %>
           <%= link_to "Attachments" %>
           <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
         <% else %>
-          <%= link_to "Attach student work" %>
+          <%= link_to "Attach student work",
+              edit_manage_assignments_outcome_coverage_assignment_path(
+                outcome_coverage_id: outcome_coverage.id,
+                assignment: outcome_coverage.assignment) %>
         <% end %>
+
+
+
         <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -37,7 +37,6 @@
 
 
         <% if outcome_coverage.assignment.attachments.present? %>
-          <%= link_to t(".attachments-expandable-link") %>
           <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
         <% else %>
           <%= link_to t(".attach-student-work"),

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -34,6 +34,13 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
+
+        <% if outcome_coverage.assignment.attachments.present? %>
+          <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
+        <% else %>
+          <%= link_to "Attach student work" %>
+        <% end %>
+
         <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -34,12 +34,13 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
-        <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
         <% if outcome_coverage.assignment.attachments.present? %>
+          <%= link_to "Attachments" %>
           <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
         <% else %>
           <%= link_to "Attach student work" %>
         <% end %>
+        <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),
             manage_assignments_outcome_coverage_path(outcome_coverage),

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -37,10 +37,10 @@
 
 
         <% if outcome_coverage.assignment.attachments.present? %>
-          <%= link_to "Attachments" %>
+          <%= link_to t(".attachments-expandable-link") %>
           <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
         <% else %>
-          <%= link_to "Attach student work",
+          <%= link_to t(".attach-student-work"),
               edit_manage_assignments_outcome_coverage_assignment_path(
                 outcome_coverage_id: outcome_coverage.id,
                 assignment: outcome_coverage.assignment) %>

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -34,14 +34,12 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
-
+        <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
         <% if outcome_coverage.assignment.attachments.present? %>
           <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
         <% else %>
           <%= link_to "Attach student work" %>
         <% end %>
-
-        <%= link_to t(".add_result"), new_manage_results_assignment_result_path(outcome_coverage.assignment) %>
       <% end %>
       <%= link_to t(".delete_outcome_coverage"),
             manage_assignments_outcome_coverage_path(outcome_coverage),

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -30,7 +30,6 @@ en:
         add_result: Add Result
         assignment_name: In %{name}
         assignment_problem: on %{problem}
-        attachments-expandable-link: Attachments
         attach-student-work: Attach student work
         edit_assignment: Edit Assignment
         delete_outcome_coverage: Delete
@@ -51,6 +50,7 @@ en:
         view: View Outcome Coverage
     courses:
       attachments:
+        attachments-expandable-link: Attachments
         delete-link: Delete
       outcome_status:
         label: Outcome %{label}

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -30,6 +30,8 @@ en:
         add_result: Add Result
         assignment_name: In %{name}
         assignment_problem: on %{problem}
+        attachments-expandable-link: Attachments
+        attach-student-work: Attach student work
         edit_assignment: Edit Assignment
         delete_outcome_coverage: Delete
         delete_outcome_coverage_confirmation: You are about to remove this
@@ -48,6 +50,8 @@ en:
         title: Manage Outcome Coverage for Your Courses
         view: View Outcome Coverage
     courses:
+      attachments:
+        delete-link: Delete
       outcome_status:
         label: Outcome %{label}
       show: &courses_show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   namespace :manage_assignments do
     root "dashboard#show"
 
-    resources :attachments, only: [:show]
+    resources :attachments, only: [:show, :destroy]
 
     resources :courses, only: [:index, :show] do
       resources :coverages, only: [:new, :edit, :create, :update]

--- a/spec/features/user_deletes_attachment_from_courses_page_spec.rb
+++ b/spec/features/user_deletes_attachment_from_courses_page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "User views attachments related to a specific assignment", js: true do
+feature "User deletes attachments related to a specific assignment", js: true do
   scenario "successfully" do
     assignment = create(:assignment)
     attachment = create(:attachment, attachable: assignment)
@@ -8,10 +8,10 @@ feature "User views attachments related to a specific assignment", js: true do
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
     click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
-
-    expect(page).to have_content(attachment.file_file_name)
-
-    click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
+    save_and_open_page
+    within("table.assignment-attachments") do
+      click_on t("manage_assignments.courses.attachments.delete-link")
+    end
 
     expect(page).to have_no_content(attachment.file_file_name)
   end

--- a/spec/features/user_views_attachments_from_courses_page_spec.rb
+++ b/spec/features/user_views_attachments_from_courses_page_spec.rb
@@ -1,14 +1,19 @@
 require "rails_helper"
 
-feature "User views attachments related to a specific assignment" do
+feature "User views attachments related to a specific assignment", js: true do
   scenario "successfully" do
     assignment = create(:assignment)
     attachment = create(:attachment, attachable: assignment)
     user = user_with_assignments_access_to(assignment.course.department)
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
+    click_on "Attachments"
 
     expect(page).to have_content(attachment.file_file_name)
+
+    click_on "Attachments"
+
+    expect(page).to have_no_content(attachment.file_file_name)
   end
 
   scenario "deletes" do
@@ -17,6 +22,7 @@ feature "User views attachments related to a specific assignment" do
     user = user_with_assignments_access_to(assignment.course.department)
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
+    click_on "Attachments"
     save_and_open_page
     within("table.assignment-attachments") do
       click_on "Delete"

--- a/spec/features/user_views_attachments_from_courses_page_spec.rb
+++ b/spec/features/user_views_attachments_from_courses_page_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+feature "User views attachments related to a specific assignment" do
+  scenario "successfully" do
+    assignment = create(:assignment)
+    attachment = create(:attachment, attachable: assignment)
+    user = user_with_assignments_access_to(assignment.course.department)
+
+    visit manage_assignments_course_path(assignment.course.id, as: user)
+
+    expect(page).to have_content(attachment.file_file_name)
+  end
+end

--- a/spec/features/user_views_attachments_from_courses_page_spec.rb
+++ b/spec/features/user_views_attachments_from_courses_page_spec.rb
@@ -7,11 +7,11 @@ feature "User views attachments related to a specific assignment", js: true do
     user = user_with_assignments_access_to(assignment.course.department)
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
-    click_on "Attachments"
+    click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
 
     expect(page).to have_content(attachment.file_file_name)
 
-    click_on "Attachments"
+    click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
 
     expect(page).to have_no_content(attachment.file_file_name)
   end
@@ -22,10 +22,10 @@ feature "User views attachments related to a specific assignment", js: true do
     user = user_with_assignments_access_to(assignment.course.department)
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
-    click_on "Attachments"
+    click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
     save_and_open_page
     within("table.assignment-attachments") do
-      click_on "Delete"
+      click_on t("manage_assignments.courses.attachments.delete-link")
     end
 
     expect(page).to have_no_content(attachment.file_file_name)

--- a/spec/features/user_views_attachments_from_courses_page_spec.rb
+++ b/spec/features/user_views_attachments_from_courses_page_spec.rb
@@ -10,4 +10,18 @@ feature "User views attachments related to a specific assignment" do
 
     expect(page).to have_content(attachment.file_file_name)
   end
+
+  scenario "deletes" do
+    assignment = create(:assignment)
+    attachment = create(:attachment, attachable: assignment)
+    user = user_with_assignments_access_to(assignment.course.department)
+
+    visit manage_assignments_course_path(assignment.course.id, as: user)
+    save_and_open_page
+    within("table.assignment-attachments") do
+      click_on "Delete"
+    end
+
+    expect(page).to have_no_content(attachment.file_file_name)
+  end
 end


### PR DESCRIPTION
This branch allows the user to view and delete attachments from the courses page. Clicking on the Assignment link expands to show all documents associated with the assignment. Once visible, a user can delete the attachment. If no attachments are associated with an assignment, the user can click Attach student work, which will direct her to the assignment edit page. 

![screen shot 2017-06-28 at 3 46 20 pm](https://user-images.githubusercontent.com/9501674/27658130-f52ab55a-5c1c-11e7-83d6-65ea6ba978c2.png)