### PR TITLE
User can view and delete attachments

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -10,4 +10,9 @@ $(function() {
       $(this).find(fileName).text(selectedFileName);
     });
   });
+
+  $(".attachments-expandable-link").on("click", function(e) {
+    e.preventDefault();
+    $(this).siblings(".assignment-attachments").toggleClass("is-hidden");
+  });
 });

--- a/app/controllers/manage_assignments/attachments_controller.rb
+++ b/app/controllers/manage_assignments/attachments_controller.rb
@@ -6,5 +6,14 @@ module ManageAssignments
 
       redirect_to @attachment.expiring_url
     end
+
+    def destroy
+      attachment = Attachment.find(params[:id])
+      authorize(attachment)
+
+      attachment.destroy!
+
+      redirect_to manage_assignments_course_path(attachment.attachable.course)
+    end
   end
 end

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -2,4 +2,8 @@ class AttachmentPolicy < ApplicationPolicy
   def show?
     user.manage_assignments?(record.course_department)
   end
+
+  def destroy?
+    show?
+  end 
 end

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,0 +1,12 @@
+<table class="assignment-attachments is-hidden">
+  <tbody>
+    <% attachments.each do |attachment| %>
+      <tr>
+        <td><%= attachment.file_file_name %></td>
+        <td><%= link_to t(".delete-link"),
+              manage_assignments_attachment_path(attachment),
+              method: :delete %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -36,6 +36,15 @@
 
     <div class="class-card-assignment-controls">
       <% if outcome_coverage.assignment.present? %>
+        <% if outcome_coverage.assignment.attachments.present? %>
+          <%= link_to t(".attachments-expandable-link"), "#", class: "attachments-expandable-link" %>
+          <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
+        <% else %>
+          <%= link_to t(".attach-student-work"),
+              edit_manage_assignments_outcome_coverage_assignment_path(
+                outcome_coverage_id: outcome_coverage.id,
+                assignment: outcome_coverage.assignment) %>
+        <% end %>
         <%= link_to new_manage_results_assignment_result_path(outcome_coverage.assignment) do %>
           <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
           <%= t(".add_result") %>

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -35,6 +35,8 @@ en:
         add_result: Add Result
         assignment_name: In %{name}
         assignment_problem: on %{problem}
+        attachments-expandable-link: Attachments
+        attach-student-work: Attach student work
         edit_assignment: Edit Assignment
         delete_outcome_coverage: Delete
         delete_outcome_coverage_confirmation: You are about to remove this
@@ -53,6 +55,8 @@ en:
         title: Manage Outcome Coverage for Your Courses
         view: View Outcome Coverage
     courses:
+      attachments:
+        delete-link: Delete
       outcome_status:
         label: Outcome %{label}
       show: &courses_show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   namespace :manage_assignments do
     root "dashboard#show"
 
-    resources :attachments, only: [:show]
+    resources :attachments, only: [:show, :destroy]
 
     resources :courses, only: [:index, :show] do
       resources :coverages, only: [:new, :edit, :create, :update]

--- a/spec/features/user_deletes_attachment_from_courses_page_spec.rb
+++ b/spec/features/user_deletes_attachment_from_courses_page_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+feature "User deletes attachments related to a specific assignment", js: true do
+  scenario "successfully" do
+    assignment = create(:assignment)
+    attachment = create(:attachment, attachable: assignment)
+    user = user_with_assignments_access_to(assignment.course.department)
+
+    visit manage_assignments_course_path(assignment.course.id, as: user)
+    click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
+
+    within(".assignment-attachments") do
+      click_on t("manage_assignments.courses.attachments.delete-link")
+    end
+
+    expect(page).to have_content(assignment.name)
+    expect(page).to have_no_content(attachment.file_file_name)
+  end
+end


### PR DESCRIPTION
This branch allows the user to view and delete attachments from the courses page. Clicking on the Attachments link located just below the outcome description expands and collapses the list of attachments associated with an assignment. If no attachments belong to an assignment, the Attachments link will instead read Attach student work. Clicking on Attach student work will redirect the user to `assignment#edit`.·

<img width="1156" alt="screen shot 2017-06-29 at 9 59 49 am" src="https://user-images.githubusercontent.com/9501674/27691361-c7ed5300-5cb1-11e7-9cef-f44ea3e67476.png">
