### PR TITLE
Pluralize "Matched Outcome" appropriately

### DIFF
--- a/app/views/manage_assignments/coverages/_coverage.html.erb
+++ b/app/views/manage_assignments/coverages/_coverage.html.erb
@@ -1,7 +1,7 @@
 <div class="class-card-heading">
   <div class="class-card-outcomes">
     <p class="outcome-letter-subhead">
-      Subject
+      <%= t(".subject") %>
     </p>
     <p class="outcome-nickname">
       <%= coverage.subject.number %>
@@ -12,7 +12,7 @@
       <%= coverage.subject.title %>
     </h2>
     <p class="class-card-heading-outcomes">
-      <%= coverage.outcome_coverages.size %> Matched Outcomes
+      <%= t(".matched_outcomes", count: coverage.outcome_coverages.size) %>
     </p>
   </div>
 </div>

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -20,6 +20,11 @@ en:
     coverages:
       coverage:
         add_another_outcome: Add an outcome
+        matched_outcomes:
+          zero: 0 Matched Outcomes
+          one: 1 Matched Outcome
+          other: "%{count} Matched Outcomes"
+        subject: Subject
       form:
         add_outcome: Add another outcome
       outcome_coverage_fields:


### PR DESCRIPTION
Before this change, a subject that had a single outcome would display "1
Matched Outcomes". Now it will correctly say "1 Matched Outcome".