### PR TITLE
User can attach a syllabus from courses page

### DIFF
--- a/app/controllers/manage_assignments/coverages_controller.rb
+++ b/app/controllers/manage_assignments/coverages_controller.rb
@@ -53,7 +53,10 @@ module ManageAssignments
     def edit_coverage_params
       params.
         require(:coverage).
-        permit(outcome_coverages_attributes: [:outcome_id, :_destroy])
+        permit(
+          attachments_attributes: [:id, :file, :_destroy],
+          outcome_coverages_attributes: [:outcome_id, :_destroy]
+        )
     end
 
     def dedupe_outcomes(coverage_params)

--- a/app/models/coverage.rb
+++ b/app/models/coverage.rb
@@ -7,6 +7,9 @@ class Coverage < ApplicationRecord
   has_many :outcomes, through: :outcome_coverages
   has_many :attachments, as: :attachable
 
+  delegate :department, to: :course, prefix: true
+  delegate :department, to: :subject, prefix: true
+
   accepts_nested_attributes_for :outcome_coverages,
     reject_if: :all_blank
 
@@ -18,6 +21,10 @@ class Coverage < ApplicationRecord
     presence: true,
     uniqueness: { scope: [:course_id, :archived], unless: :archived }
   validate :must_have_outcomes
+
+  def attachment
+    attachments.first
+  end
 
   private
 

--- a/app/views/manage_assignments/coverages/_coverage.html.erb
+++ b/app/views/manage_assignments/coverages/_coverage.html.erb
@@ -13,7 +13,15 @@
     </h2>
     <p class="class-card-heading-outcomes">
       <%= t(".matched_outcomes", count: coverage.outcome_coverages.size) %>
-    </p>
+      <div>
+        <% if coverage.attachments.present? %>
+          <%= link_to coverage.attachment.name,
+            manage_assignments_attachment_path(coverage.attachment) %>
+        <% else %>
+          <%= link_to t(".attach-syllabus"),
+            edit_manage_assignments_course_coverage_path(coverage, course_id: coverage.course_id) %>
+        <% end %>
+      </div>
   </div>
 </div>
 

--- a/app/views/manage_assignments/coverages/_form.html.erb
+++ b/app/views/manage_assignments/coverages/_form.html.erb
@@ -19,8 +19,6 @@
     class: "headline-poster headline-poster-faint" %>
 </div>
 
-<% if form.object.new_record? %>
-  <%= render "attachments/nested_form", form: form %>
-<% end %>
+<%= render "attachments/nested_form", form: form %>
 
 <%= render "manage_assignments/madlib_controls", form: form %>

--- a/app/views/manage_assignments/coverages/edit.html.erb
+++ b/app/views/manage_assignments/coverages/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :full_bleed do %>
   <div class="madlib-header">
     <h1 class="headline-narrow">
-      Add Outcomes
+      Add Outcomes or a Syllabus
     </h1>
     <h2 class="headline-narrow-subhead">
       <%= @coverage.course.number %>

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -20,6 +20,7 @@ en:
     coverages:
       coverage:
         add_another_outcome: Add an outcome
+        attach-syllabus: Attach a syllabus
         matched_outcomes:
           zero: 0 Matched Outcomes
           one: 1 Matched Outcome

--- a/spec/features/user_views_syllabus_spec.rb
+++ b/spec/features/user_views_syllabus_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+feature "User views attachments related to a specific coverage" do
+  scenario "coverage has an attachment" do
+    coverage = create(:coverage)
+    attachment = create(:attachment, attachable: coverage)
+    user = user_with_assignments_access_to(coverage.course_department)
+
+    visit manage_assignments_course_path(coverage.course.id, as: user)
+
+    expect(page).to have_content attachment.file_file_name
+  end
+
+  scenario "coverage does not have an attachment" do
+    coverage = create(:coverage)
+    user = user_with_assignments_access_to(coverage.course_department)
+
+    visit manage_assignments_course_path(coverage.course.id, as: user)
+
+    expect(page). to have_content t("manage_assignments.coverages.coverage.attach-syllabus")
+  end
+end


### PR DESCRIPTION
A user can now attach a syllabus from the `manage_assignments_courses_path`. The button Attach a syllabus will redirect the user to `coverage#edit`. If a syllabus has already been attached, the file name will appear as a downloadable link. 

![screen shot 2017-06-29 at 6 20 20 pm](https://user-images.githubusercontent.com/9501674/27713101-fe5f2468-5cf7-11e7-8380-d1e871030d28.png)
