### PR TITLE
Link to persisted attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -4,7 +4,7 @@ class Attachment < ApplicationRecord
   belongs_to :attachable, polymorphic: true
 
   has_attached_file :file,
-    url: "/attachments/:id",
+    url: "/attachments/:attachable_type/:attachable_id/:updated_at/:filename",
     path: ":attachments_root/:attachable_type/:attachable_id/:updated_at/:filename",
     s3_permissions: :private
 
@@ -15,7 +15,7 @@ class Attachment < ApplicationRecord
   end
 
   def expiring_url
-    file.expiring_url(Time.now + EXPIRE_TIMEFRAME)
+    file.expiring_url(EXPIRE_TIMEFRAME)
   end
 
   def course_department

--- a/app/views/attachments/_fields.html.erb
+++ b/app/views/attachments/_fields.html.erb
@@ -3,7 +3,7 @@
   <%= f.file_field :file, as: :file, class: "is-hidden" %>
 
   <% if f.object.persisted? %>
-    <span class="file-name"><%= f.object.name %></span>
+    <%= link_to f.object.name, manage_assignments_attachment_path(f.object), class: "file-name" %>
   <% else %>
     <span class="file-name">
       <%= t(".mid-attachment") %>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -2,10 +2,12 @@
   <tbody>
     <% attachments.each do |attachment| %>
       <tr>
-        <td><%= attachment.file_file_name %></td>
-        <td><%= link_to t(".delete-link"),
-              manage_assignments_attachment_path(attachment),
-              method: :delete %></td>
+        <td>
+          <%= link_to attachment.name, manage_assignments_attachment_path(attachment) %>
+        </td>
+        <td>
+          <%= link_to t(".delete-link"), manage_assignments_attachment_path(attachment), method: :delete %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
   config.action_view.raise_on_missing_translations = true
   config.action_controller.action_on_unpermitted_parameters = :raise
+  config.public_file_server.enabled = true
   config.read_encrypted_secrets = ENV["RAILS_MASTER_KEY"].present? ||
     File.exist?("config/secrets.yml.key")
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   config.cache_classes = true
   config.eager_load = false
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = true
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
When we display persisted attachments in the class cards or on the form,
we should offer the ability to access the file by clicking on the name.

This also includes a fix to the `expiring_url` method which is supposed to
take a duration, not a timestamp.

Finally, I updated the `url` configuration so the ultimate redirection to the file works in dev when we are serving files from the filesystem.