### PR TITLE
User views attachment number

### DIFF
--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -39,7 +39,10 @@
         <%= inline_svg "paper_clip.svg", class: "add-item-icon" %>
 
         <% if outcome_coverage.assignment.attachments.present? %>
-          <%= link_to t(".attachments-expandable-link"), "#", class: "attachments-expandable-link class-card-assignment-control" %>
+          <%= link_to "#", class: "attachments-expandable-link" do %>
+            <%= t(".attachments-expandable-link") %>
+            <span><%= outcome_coverage.assignment.attachments.size %></span>
+          <% end %>
         <% else %>
           <%= link_to t(".attach-student-work"),
               edit_manage_assignments_outcome_coverage_assignment_path(

--- a/spec/features/user_deletes_attachment_from_courses_page_spec.rb
+++ b/spec/features/user_deletes_attachment_from_courses_page_spec.rb
@@ -1,12 +1,19 @@
 require "rails_helper"
 
-feature "User deletes attachments related to a specific assignment", js: true do
+feature "User views attachment count and deletes attachments related to a
+specific assignment", js: true do
   scenario "successfully" do
     assignment = create(:assignment)
     attachment = create(:attachment, attachable: assignment)
+    attachment_count = assignment.attachments.size
     user = user_with_assignments_access_to(assignment.course.department)
 
     visit manage_assignments_course_path(assignment.course.id, as: user)
+
+    within(".class-card-assignment-controls") do
+      expect(page).to have_content(attachment_count)
+    end
+
     click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
 
     within(".assignment-attachments") do
@@ -15,5 +22,9 @@ feature "User deletes attachments related to a specific assignment", js: true do
 
     expect(page).to have_content(assignment.name)
     expect(page).to have_no_content(attachment.file_file_name)
+
+    within(".class-card-assignment-controls") do
+      expect(page).to have_no_content(attachment_count)
+    end
   end
 end


### PR DESCRIPTION
This branch adds the number of attachments associated with an attachment next to the attachments link.

![screen shot 2017-06-29 at 4 45 48 pm](https://user-images.githubusercontent.com/9501674/27710209-e6658b0a-5cec-11e7-95c6-3d31f029d41e.png)