### PR TITLE
User can add another attachment

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,5 +10,6 @@
 @import "refills/*";
 @import "selectize";
 @import "selectize.default";
+@import "utilities/*";
 @import "components/*";
 @import "pages/*";

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -45,7 +45,6 @@ caption {
 }
 
 .table-section-header {
-  background-color: $lightest-gray;
   color: $medium-gray;
   font-size: $smallest-font-size;
   font-weight: $bold;

--- a/app/assets/stylesheets/components/_add-item.scss
+++ b/app/assets/stylesheets/components/_add-item.scss
@@ -57,7 +57,6 @@
   margin-top: $large-spacing;
 
   .class-card & {
-    background-color: $lightest-gray;
     font-size: $small-font-size;
     margin-top: $base-spacing;
   }

--- a/app/assets/stylesheets/utilities/_colors.scss
+++ b/app/assets/stylesheets/utilities/_colors.scss
@@ -1,0 +1,3 @@
+.fill-lightest-gray {
+  background: $lightest-gray;
+}

--- a/app/assets/stylesheets/utilities/_margin.scss
+++ b/app/assets/stylesheets/utilities/_margin.scss
@@ -1,0 +1,4 @@
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -4,7 +4,7 @@
 
 <table class="activity-feed">
   <% @activity_feed.grouped_activities.each do |date, activities| %>
-    <tr class="table-section-header">
+    <tr class="table-section-header fill-lightest-gray">
       <td class="activity-header-date" colspan="3"><%= relative_date(date) %></td>
       <td class="activity-header-count"><%= t(".activity_count", count: activities.size) %></td>
     </tr>

--- a/app/views/manage_assignments/courses/_attachments.html.erb
+++ b/app/views/manage_assignments/courses/_attachments.html.erb
@@ -1,11 +1,23 @@
 <ul class="assignment-attachments attachments is-hidden">
-  <% attachments.each do |attachment| %>
-    <li class="attachment">
+  <% assignment.attachments.each do |attachment| %>
+    <li class="attachment fill-lightest-gray">
       <%= link_to attachment.name,
           manage_assignments_attachment_path(attachment) %>
       <%= link_to t(".delete-link"),
           manage_assignments_attachment_path(attachment),
           method: :delete %>
+    </li>
+  <% end %>
+
+  <% if assignment.attachments.present? %>
+    <li class="attachment">
+      <%= link_to(edit_manage_assignments_outcome_coverage_assignment_path(
+            outcome_coverage_id: assignment.outcome_coverage.id,
+            assignment: assignment),
+            class: "mx-auto") do %>
+        <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
+        <%= t(".add_another_attachment") %>
+      <% end %>
     </li>
   <% end %>
 </ul>

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -57,7 +57,8 @@
           <%= t(".add_result") %>
         <% end %>
 
-        <%= render "attachments", attachments: outcome_coverage.assignment.attachments %>
+        <%= render "attachments",
+            assignment: outcome_coverage.assignment %>
       <% end %>
 
       <%= link_to t(".delete_outcome_coverage"),

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -56,6 +56,7 @@ en:
         view: View Outcome Coverage
     courses:
       attachments:
+        add_another_attachment: Add another attachment
         delete-link: Delete
       outcome_status:
         label: Outcome %{label}


### PR DESCRIPTION
A user can now add another attachment from the `manage_assignments_courses_path`. Clicking the Add another attachment button redirects the user to `assignments#edit`.

![screen shot 2017-06-29 at 5 39 04 pm](https://user-images.githubusercontent.com/9501674/27711672-e5be43e0-5cf1-11e7-867b-2ce07c657376.png)
