### PR TITLE
Add back a missing attachment icon

### DIFF
--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -48,11 +48,14 @@
             </span>
           </div>
         <% else %>
-          <%= link_to t(".attach-student-work"),
+          <%= link_to(
               edit_manage_assignments_outcome_coverage_assignment_path(
                 outcome_coverage_id: outcome_coverage.id,
                 assignment: outcome_coverage.assignment),
-                class: "class-card-assignment-control" %>
+                class: "class-card-assignment-control") do %>
+            <%= inline_svg "paper_clip.svg", class: "add-item-icon" %>
+            <%= t(".attach-student-work") %>
+          <% end %>
         <% end %>
 
         <%= link_to new_manage_results_assignment_result_path(outcome_coverage.assignment),


### PR DESCRIPTION
This PR returns a missing attachment icon back to its rightful home.

*before*
![screen shot 2017-07-03 at 4 21 30 pm](https://user-images.githubusercontent.com/5566826/27806972-d4e1e898-600b-11e7-9daa-6d06346cbae3.png)


*after*
![screen shot 2017-07-03 at 4 21 41 pm](https://user-images.githubusercontent.com/5566826/27806949-b8af854a-600b-11e7-8a7a-1bd322855900.png)


