### PR TITLE
View attachments associated with coverages

### DIFF
--- a/app/assets/stylesheets/components/_add-item.scss
+++ b/app/assets/stylesheets/components/_add-item.scss
@@ -56,7 +56,8 @@
   font-family: $sans-serif-narrow;
   margin-top: $large-spacing;
 
-  .class-card & {
+  .class-card &,
+  .class-card-heading & {
     font-size: $small-font-size;
     margin-top: $base-spacing;
   }
@@ -76,8 +77,4 @@
     flex: 1;
     text-align: right;
   }
-}
-
-.is-hidden {
-  display: none;
 }

--- a/app/assets/stylesheets/components/_class-card-heading.scss
+++ b/app/assets/stylesheets/components/_class-card-heading.scss
@@ -1,0 +1,59 @@
+.class-card-heading {
+  @include border-top-radius($base-border-radius);
+  @include padding($medium-spacing $base-spacing);
+  align-items: center;
+  background-color: $brown;
+  border-bottom: $thick-border-width solid rgba(black, 0.15);
+  color: $white;
+  display: flex;
+  flex-wrap: wrap;
+  line-height: $heading-line-height;
+  margin-bottom: 0;
+
+  a {
+    @include anchor-color($white);
+    border-bottom: $base-border-width solid transparent;
+    font-family: $sans-serif-narrow;
+    padding-bottom: $thick-border-width;
+    transition: $base-transition;
+
+    &:active,
+    &:focus,
+    &:hover {
+      border-bottom-color: $white;
+    }
+  }
+
+  svg {
+    fill: $white;
+  }
+
+  .attachments,
+  .attachment {
+    border-color: rgba($dark-gray, 0.35);
+  }
+
+  .attachment {
+    background-color: rgba($dark-gray, 0.15);
+
+    &:last-of-type {
+      background-color: transparent;
+    }
+  }
+}
+
+.class-card-heading-meta {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-bottom: $small-spacing;
+}
+
+.class-card-heading-outcomes {
+  color: tint($medium-gray, 18%);
+  font-family: $sans-serif-narrow;
+  font-size: $small-font-size;
+  margin-bottom: 0;
+  text-align: right;
+}

--- a/app/assets/stylesheets/components/_class-card.scss
+++ b/app/assets/stylesheets/components/_class-card.scss
@@ -4,31 +4,18 @@
   border: $thick-border-width solid tint($lighter-border-color, 25%);
   border-top: 0;
   padding: $base-spacing;
+
+  .attachment:not(:last-of-type) {
+    background-color: $lightest-gray;
+  }
 }
 
 .class-card-subject-title {
   color: $white;
   font-family: $sans-serif-narrow;
   font-size: 165%;
+  line-height: $heading-line-height;
   margin: 0;
-}
-
-.class-card-heading-outcomes {
-  color: tint($medium-gray, 18%);
-  font-family: $sans-serif-narrow;
-  margin-bottom: 0;
-}
-
-.class-card-heading {
-  @include border-top-radius($base-border-radius);
-  @include padding($medium-spacing $base-spacing);
-  align-items: center;
-  background-color: $brown;
-  border-bottom: $thick-border-width solid rgba(black, 0.15);
-  color: $white;
-  display: flex;
-  flex-wrap: wrap;
-  margin-bottom: 0;
 }
 
 .class-card-subject-number {
@@ -79,6 +66,7 @@
 
 .class-card-outcomes {
   @include margin($smallest-spacing $small-spacing $small-spacing null);
+  align-self: flex-start;
   flex: 0.25 auto;
   line-height: $heading-line-height;
   width: 100px;
@@ -114,6 +102,6 @@
 }
 
 .class-card-assignment-control {
-  margin-right: $base-spacing;
   display: inline-block;
+  margin-right: $base-spacing;
 }

--- a/app/assets/stylesheets/utilities/_hide.scss
+++ b/app/assets/stylesheets/utilities/_hide.scss
@@ -1,0 +1,3 @@
+.is-hidden {
+  display: none;
+}

--- a/app/views/manage_assignments/coverages/_coverage.html.erb
+++ b/app/views/manage_assignments/coverages/_coverage.html.erb
@@ -8,26 +8,42 @@
     </p>
   </div>
   <div class="class-card-assignments">
-    <h2 class="class-card-subject-title">
-      <%= coverage.subject.title %>
-    </h2>
-    <p class="class-card-heading-outcomes">
-      <%= t(".matched_outcomes", count: coverage.outcome_coverages.size) %>
-      <div>
-        <% if coverage.attachments.present? %>
-          <%= link_to coverage.attachment.name,
-            manage_assignments_attachment_path(coverage.attachment) %>
-        <% else %>
-          <%= link_to t(".attach-syllabus"),
-            edit_manage_assignments_course_coverage_path(coverage, course_id: coverage.course_id) %>
+    <div class="class-card-heading-meta">
+      <h2 class="class-card-subject-title">
+        <%= coverage.subject.title %>
+      </h2>
+      <p class="class-card-heading-outcomes">
+        <%= t(".matched_outcomes", count: coverage.outcome_coverages.size) %>
+      </p>
+    </div>
+
+    <div>
+      <% if coverage.attachments.present? %>
+      <div class="attachments-expandable-link class-card-assignment-control">
+        <%= link_to "#" do %>
+          <%= inline_svg "paper_clip.svg", class: "add-item-icon" %>
+          <%= t(".attachments-expandable-link") %>
         <% end %>
+        <span class="emphasized-tab-digit emphasized-tab-digit-small">
+          <%= coverage.attachments.size %>
+        </span>
       </div>
+      <% else %>
+        <%= link_to(edit_manage_assignments_course_coverage_path(coverage, course_id: coverage.course_id)) do %>
+          <%= inline_svg "paper_clip.svg", class: "add-item-icon" %>
+          <%= t(".attach-syllabus") %>
+        <% end %>
+      <% end %>
+      <%= render "manage_assignments/shared/attachments",
+        item: coverage,
+        edit_path: edit_manage_assignments_course_coverage_path(
+          coverage,
+          course_id: coverage.course_id) %>
+    </div>
   </div>
 </div>
-
 <div class="class-card">
   <%= render coverage.outcome_coverages.sort_by(&:outcome_label) %>
-
   <%= link_to(edit_manage_assignments_course_coverage_path(coverage, course_id: coverage.course_id), html_options = {class: "add-item add-item-short"}) do %>
     <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
     <%= t(".add_another_outcome") %>

--- a/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
+++ b/app/views/manage_assignments/outcome_coverages/_outcome_coverage.html.erb
@@ -64,8 +64,11 @@
           <%= t(".add_result") %>
         <% end %>
 
-        <%= render "attachments",
-            assignment: outcome_coverage.assignment %>
+        <%= render "manage_assignments/shared/attachments",
+            item: outcome_coverage.assignment,
+            edit_path: edit_manage_assignments_outcome_coverage_assignment_path(
+                          outcome_coverage_id: outcome_coverage.id,
+                          assignment: outcome_coverage.assignment)  %>
       <% end %>
 
       <%= link_to t(".delete_outcome_coverage"),

--- a/app/views/manage_assignments/shared/_attachments.html.erb
+++ b/app/views/manage_assignments/shared/_attachments.html.erb
@@ -1,23 +1,18 @@
 <ul class="assignment-attachments attachments is-hidden">
-  <% assignment.attachments.each do |attachment| %>
-    <li class="attachment fill-lightest-gray">
+  <% item.attachments.each do |attachment| %>
+    <li class="attachment">
       <%= link_to attachment.name,
           manage_assignments_attachment_path(attachment) %>
-      <%= link_to t(".delete-link"),
+      <%= link_to t(".delete_link"),
           manage_assignments_attachment_path(attachment),
           method: :delete %>
     </li>
   <% end %>
 
-  <% if assignment.attachments.present? %>
     <li class="attachment">
-      <%= link_to(edit_manage_assignments_outcome_coverage_assignment_path(
-            outcome_coverage_id: assignment.outcome_coverage.id,
-            assignment: assignment),
-            class: "mx-auto") do %>
+      <%= link_to(edit_path, class: "mx-auto") do %>
         <%= inline_svg "plus_sign.svg", class: "add-item-icon" %>
         <%= t(".add_another_attachment") %>
       <% end %>
     </li>
-  <% end %>
 </ul>

--- a/app/views/manage_results/results/_form.html.erb
+++ b/app/views/manage_results/results/_form.html.erb
@@ -13,7 +13,6 @@
   <%= form.input :year,
       collection: Result::YEARS,
       headline: "of" %>
-
 </div>
 
 <div class="madlib-statement">

--- a/config/locales/manage_assignments.en.yml
+++ b/config/locales/manage_assignments.en.yml
@@ -20,6 +20,7 @@ en:
     coverages:
       coverage:
         add_another_outcome: Add an outcome
+        attachments-expandable-link: Attachments
         attach-syllabus: Attach a syllabus
         matched_outcomes:
           zero: 0 Matched Outcomes
@@ -56,9 +57,6 @@ en:
         title: Manage Outcome Coverage for Your Courses
         view: View Outcome Coverage
     courses:
-      attachments:
-        add_another_attachment: Add another attachment
-        delete-link: Delete
       outcome_status:
         label: Outcome %{label}
       show: &courses_show
@@ -69,3 +67,7 @@ en:
       show_without_coverages:
         <<: *courses_show
         no_classes: "%{name} doesn’t have any classes yet"
+    shared:
+      attachments:
+        add_another_attachment: Add another attachment
+        delete_link: Delete

--- a/spec/features/user_deletes_attachment_from_a_coverage_spec.rb
+++ b/spec/features/user_deletes_attachment_from_a_coverage_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+feature "User views attachment count and deletes an attachment from
+  a coverage", js: true do
+  scenario "successfully" do
+    coverage = create(:coverage)
+    attachment = create(:attachment, attachable: coverage)
+    attachment_count = coverage.attachments.size
+    subject_name = coverage.subject.title
+    user = user_with_assignments_access_to(coverage.course.department)
+
+    visit manage_assignments_course_path(coverage.course.id, as: user)
+
+    within(".class-card-assignment-control") do
+      expect(page).to have_content(attachment_count)
+    end
+
+    click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
+
+    delete_attachment
+
+    expect(page).to have_content(subject_name)
+    expect(page).to have_no_content(attachment.file_file_name)
+    expect(page).to have_content t("manage_assignments.coverages.coverage.attach-syllabus")
+
+    within(".class-card-heading") do
+      expect(page).to have_no_content t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
+    end
+  end
+
+  def delete_attachment
+    within(".assignment-attachments") do
+      click_on t("manage_assignments.shared.attachments.delete_link")
+    end
+  end
+end

--- a/spec/features/user_deletes_attachment_from_an_assignment_spec.rb
+++ b/spec/features/user_deletes_attachment_from_an_assignment_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-feature "User views attachment count and deletes attachments related to a
-specific assignment", js: true do
+feature "User views attachment count and deletes an attachment from
+  an assignment", js: true do
   scenario "successfully" do
     assignment = create(:assignment)
     attachment = create(:attachment, attachable: assignment)
@@ -16,15 +16,19 @@ specific assignment", js: true do
 
     click_on t("manage_assignments.outcome_coverages.outcome_coverage.attachments-expandable-link")
 
-    within(".assignment-attachments") do
-      click_on t("manage_assignments.courses.attachments.delete-link")
-    end
+    delete_assignment
 
     expect(page).to have_content(assignment.name)
     expect(page).to have_no_content(attachment.file_file_name)
 
     within(".class-card-assignment-controls") do
       expect(page).to have_no_content(attachment_count)
+    end
+  end
+
+  def delete_assignment
+    within(".assignment-attachments") do
+      click_on t("manage_assignments.shared.attachments.delete_link")
     end
   end
 end


### PR DESCRIPTION
This branch allows the user to view all attachments associated with a
coverage. By clicking Add a syllabus, the user can attach a file or
files associated with the entire coverage. The expected user behavior is
that each coverage has only one document (a syllabus). From the
expandable view the user can download the current attachments, delete
them, or add another attachment.

![screen shot 2017-07-05 at 4 23 00 pm](https://user-images.githubusercontent.com/9501674/27883369-48352ca4-619e-11e7-8fbc-466aab74b18f.png)
